### PR TITLE
feat: add file hash tracking and duplicate file detection with backfill script

### DIFF
--- a/src/ravioli/backend/api/v1/endpoints/data.py
+++ b/src/ravioli/backend/api/v1/endpoints/data.py
@@ -157,3 +157,24 @@ async def delete_file(file_id: uuid.UUID, db: Session = Depends(get_db)):
     except Exception as e:
         db.rollback()
         raise HTTPException(status_code=500, detail=f"Failed to delete file: {str(e)}")
+
+@router.patch("/files/{file_id}", response_model=schemas.UploadedFile)
+async def update_file(
+    file_id: uuid.UUID,
+    file_update: schemas.UploadedFileUpdate,
+    db: Session = Depends(get_db)
+):
+    db_file = db.execute(select(UploadedFile).where(UploadedFile.id == file_id)).scalar_one_or_none()
+    if not db_file:
+        raise HTTPException(status_code=404, detail="File not found")
+        
+    if file_update.description is not None:
+        db_file.description = file_update.description
+        
+    try:
+        db.commit()
+        db.refresh(db_file)
+        return db_file
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=f"Failed to update file: {str(e)}")

--- a/src/ravioli/backend/api/v1/endpoints/data.py
+++ b/src/ravioli/backend/api/v1/endpoints/data.py
@@ -1,6 +1,7 @@
 import re
 import shutil
 import uuid
+import hashlib
 from pathlib import Path
 from typing import List
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
@@ -19,6 +20,14 @@ router = APIRouter()
 UPLOAD_DIR = settings.local_data_path / "uploads"
 UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
 
+async def calculate_hash(file: UploadFile) -> str:
+    sha256_hash = hashlib.sha256()
+    # Read in chunks to avoid memory issues
+    while content := await file.read(8192):
+        sha256_hash.update(content)
+    await file.seek(0)  # Important: reset pointer for subsequent reads
+    return sha256_hash.hexdigest()
+
 @router.post("/upload", response_model=schemas.UploadedFile)
 async def upload_file(
     file: UploadFile = File(...),
@@ -26,6 +35,23 @@ async def upload_file(
 ):
     if not file.filename.endswith('.csv'):
         raise HTTPException(status_code=400, detail="Only CSV files are supported at this moment.")
+
+    # Generate hash to check for duplicates
+    file_hash = await calculate_hash(file)
+    
+    # Check if file with same hash already exists
+    query = select(UploadedFile).where(UploadedFile.file_hash == file_hash)
+    existing_file = db.execute(query).scalar_one_or_none()
+    
+    if existing_file:
+        # If it exists and was successful, we can just return it
+        if existing_file.status == "completed":
+            # Inform the user it was a duplicate
+            existing_file.is_duplicate = True
+            return existing_file
+        else:
+            # If it failed or is pending, we proceed to retry
+            pass
 
     file_id = uuid.uuid4()
     extension = Path(file.filename).suffix
@@ -35,7 +61,6 @@ async def upload_file(
     # Generate a clean table name from the filename
     base_name = Path(file.filename).stem
     table_name = "".join(c if c.isalnum() else "_" for c in base_name).lower()
-    # Add a suffix to ensure uniqueness if needed, but for now we'll overwrite
     
     try:
         # Save file to disk
@@ -50,6 +75,7 @@ async def upload_file(
             content_type=file.content_type,
             size_bytes=file_path.stat().st_size,
             table_name=table_name,
+            file_hash=file_hash,
             status="pending"
         )
         db.add(db_file)

--- a/src/ravioli/backend/api/v1/endpoints/data.py
+++ b/src/ravioli/backend/api/v1/endpoints/data.py
@@ -131,3 +131,29 @@ async def get_table_preview(table_name: str):
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to fetch preview: {str(e)}")
+
+@router.delete("/files/{file_id}")
+async def delete_file(file_id: uuid.UUID, db: Session = Depends(get_db)):
+    # 1. Fetch record
+    db_file = db.execute(select(UploadedFile).where(UploadedFile.id == file_id)).scalar_one_or_none()
+    if not db_file:
+        raise HTTPException(status_code=404, detail="File not found")
+        
+    try:
+        # 2. Drop table from DuckDB
+        if db_file.table_name:
+            duckdb_manager.connection.execute(f"DROP TABLE IF EXISTS {db_file.table_name}")
+            
+        # 3. Delete physical file
+        file_path = UPLOAD_DIR / db_file.filename
+        if file_path.exists():
+            file_path.unlink()
+            
+        # 4. Delete Postgres record
+        db.delete(db_file)
+        db.commit()
+        
+        return {"status": "success", "message": "File and associated data deleted successfully"}
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=f"Failed to delete file: {str(e)}")

--- a/src/ravioli/backend/core/models.py
+++ b/src/ravioli/backend/core/models.py
@@ -78,6 +78,7 @@ class UploadedFile(Base):
     # Table name in DuckDB
     table_name: Mapped[str] = mapped_column(String(255), nullable=False)
     row_count: Mapped[Optional[int]] = mapped_column()
+    description: Mapped[Optional[str]] = mapped_column(Text)
     
     # Ingestion status: pending, completed, failed
     status: Mapped[str] = mapped_column(String(50), default="pending")

--- a/src/ravioli/backend/core/models.py
+++ b/src/ravioli/backend/core/models.py
@@ -83,5 +83,7 @@ class UploadedFile(Base):
     status: Mapped[str] = mapped_column(String(50), default="pending")
     error_message: Mapped[Optional[str]] = mapped_column(Text)
     
+    file_hash: Mapped[Optional[str]] = mapped_column(String(64), index=True)
+    
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))

--- a/src/ravioli/backend/core/schemas.py
+++ b/src/ravioli/backend/core/schemas.py
@@ -74,10 +74,12 @@ class UploadedFileBase(BaseModel):
     row_count: Optional[int] = None
     status: str
     error_message: Optional[str] = None
+    file_hash: Optional[str] = None
 
 class UploadedFile(UploadedFileBase):
     id: UUID
     created_at: datetime
     updated_at: datetime
+    is_duplicate: bool = False
 
     model_config = ConfigDict(from_attributes=True)

--- a/src/ravioli/backend/core/schemas.py
+++ b/src/ravioli/backend/core/schemas.py
@@ -72,6 +72,7 @@ class UploadedFileBase(BaseModel):
     size_bytes: int
     table_name: str
     row_count: Optional[int] = None
+    description: Optional[str] = None
     status: str
     error_message: Optional[str] = None
     file_hash: Optional[str] = None
@@ -83,3 +84,6 @@ class UploadedFile(UploadedFileBase):
     is_duplicate: bool = False
 
     model_config = ConfigDict(from_attributes=True)
+
+class UploadedFileUpdate(BaseModel):
+    description: Optional[str] = None

--- a/src/ravioli/backend/scripts/backfill_hashes.py
+++ b/src/ravioli/backend/scripts/backfill_hashes.py
@@ -1,0 +1,43 @@
+import hashlib
+import uuid
+from pathlib import Path
+from sqlalchemy import select, update
+from ravioli.backend.core.database import SessionLocal
+from ravioli.backend.core.models import UploadedFile
+from ravioli.backend.core.config import settings
+
+def calculate_hash(file_path: Path) -> str:
+    sha256_hash = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        while content := f.read(8192):
+            sha256_hash.update(content)
+    return sha256_hash.hexdigest()
+
+def backfill():
+    db = SessionLocal()
+    try:
+        # Get all files with missing hash
+        query = select(UploadedFile).where(UploadedFile.file_hash == None)
+        files = db.execute(query).scalars().all()
+        
+        print(f"Found {len(files)} files without hash.")
+        
+        for file_record in files:
+            file_path = settings.local_data_path / "uploads" / file_record.filename
+            if file_path.exists():
+                file_hash = calculate_hash(file_path)
+                file_record.file_hash = file_hash
+                print(f"Updated hash for {file_record.filename}: {file_hash}")
+            else:
+                print(f"File not found on disk: {file_record.filename}")
+        
+        db.commit()
+        print("Backfill completed.")
+    except Exception as e:
+        print(f"Error during backfill: {e}")
+        db.rollback()
+    finally:
+        db.close()
+
+if __name__ == "__main__":
+    backfill()

--- a/src/ravioli/backend/scripts/backfill_hashes.py
+++ b/src/ravioli/backend/scripts/backfill_hashes.py
@@ -1,7 +1,6 @@
 import hashlib
-import uuid
 from pathlib import Path
-from sqlalchemy import select, update
+from sqlalchemy import select
 from ravioli.backend.core.database import SessionLocal
 from ravioli.backend.core.models import UploadedFile
 from ravioli.backend.core.config import settings
@@ -17,7 +16,7 @@ def backfill():
     db = SessionLocal()
     try:
         # Get all files with missing hash
-        query = select(UploadedFile).where(UploadedFile.file_hash == None)
+        query = select(UploadedFile).where(UploadedFile.file_hash.is_(None))
         files = db.execute(query).scalars().all()
         
         print(f"Found {len(files)} files without hash.")

--- a/src/ravioli/frontend/src/components/Data.ts
+++ b/src/ravioli/frontend/src/components/Data.ts
@@ -1,5 +1,6 @@
 import { store } from '../store';
 import { api } from '../services/api';
+import { formatBytes } from '../utils/formatters';
 
 export function renderData() {
   const container = document.createElement('main');
@@ -68,9 +69,10 @@ export function renderData() {
                     </div>
                   </td>
                   <td class="px-8 py-5">
-                    <div class="flex items-center gap-2 group/desc max-w-xs">
-                      <span class="text-neutral-400 text-sm truncate" title="${file.description || ''}">${file.description || '<span class="italic opacity-50">No description</span>'}</span>
-                      <button class="btn-edit-desc p-1 rounded-md opacity-0 group-hover/desc:opacity-100 hover:bg-white/10 text-neutral-500 hover:text-primary transition-all flex-shrink-0" data-id="${file.id}" data-desc="${file.description || ''}" title="Edit Description">
+                    <div class="desc-container flex items-center gap-2 group/desc max-w-xs w-full" data-id="${file.id}">
+                      <span class="desc-text text-neutral-400 text-sm truncate cursor-pointer hover:text-neutral-200 transition-colors flex-1" title="${file.description || ''}" data-desc="${file.description || ''}">${file.description || '<span class="italic opacity-50">Add description...</span>'}</span>
+                      <input type="text" class="desc-input hidden w-full bg-surface-container-highest border border-primary/30 rounded px-2 py-1 text-sm text-neutral-200 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/50 transition-all" value="${file.description || ''}" placeholder="Enter description..." />
+                      <button class="btn-edit-desc p-1 rounded-md opacity-0 group-hover/desc:opacity-100 hover:bg-white/10 text-neutral-500 hover:text-primary transition-all flex-shrink-0" title="Edit Description">
                         <span class="material-symbols-outlined text-[16px]">edit</span>
                       </button>
                     </div>
@@ -82,7 +84,7 @@ export function renderData() {
                     ${file.row_count ? file.row_count.toLocaleString() : '--'}
                   </td>
                   <td class="px-8 py-5 text-neutral-400 text-sm">
-                    ${(file.size_bytes / 1024).toFixed(1)} KB
+                    ${formatBytes(file.size_bytes)}
                   </td>
                   <td class="px-8 py-5">
                     <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] uppercase tracking-wider font-bold ${
@@ -191,22 +193,71 @@ export function renderData() {
     });
   });
 
-  container.querySelectorAll('.btn-edit-desc').forEach(btn => {
-    btn.addEventListener('click', async () => {
-      const fileId = btn.getAttribute('data-id');
-      const currentDesc = btn.getAttribute('data-desc') || '';
-      if (fileId) {
-        const newDesc = prompt('Enter a description for this data:', currentDesc);
-        if (newDesc !== null && newDesc !== currentDesc) {
+  container.querySelectorAll('.desc-container').forEach(descContainer => {
+    const textSpan = descContainer.querySelector('.desc-text') as HTMLSpanElement;
+    const inputEl = descContainer.querySelector('.desc-input') as HTMLInputElement;
+    const editBtn = descContainer.querySelector('.btn-edit-desc') as HTMLButtonElement;
+    const fileId = descContainer.getAttribute('data-id');
+
+    const startEditing = () => {
+      textSpan.classList.add('hidden');
+      editBtn.classList.add('hidden');
+      inputEl.classList.remove('hidden');
+      inputEl.focus();
+      // Move cursor to end
+      inputEl.selectionStart = inputEl.selectionEnd = inputEl.value.length;
+    };
+
+    const stopEditing = async (save: boolean) => {
+      // Prevent double-saving if blur is triggered after Enter
+      if (inputEl.classList.contains('hidden')) return; 
+
+      inputEl.classList.add('hidden');
+      textSpan.classList.remove('hidden');
+      editBtn.classList.remove('hidden');
+      
+      if (save && fileId) {
+        const newDesc = inputEl.value.trim();
+        const currentDesc = textSpan.getAttribute('data-desc') || '';
+        
+        if (newDesc !== currentDesc) {
           try {
+            // Optimistic UI update
+            textSpan.textContent = newDesc;
+            if (!newDesc) textSpan.innerHTML = '<span class="italic opacity-50">Add description...</span>';
+            textSpan.setAttribute('title', newDesc);
+            textSpan.setAttribute('data-desc', newDesc);
+            
             await api.updateFileDescription(fileId, newDesc);
+            // Optionally sync store in background
             const updatedFiles = await api.listFiles();
             store.setUploadedFiles(updatedFiles);
           } catch (err) {
             console.error('Update description failed', err);
+            // Revert UI on failure
+            inputEl.value = currentDesc;
+            textSpan.textContent = currentDesc;
+            if (!currentDesc) textSpan.innerHTML = '<span class="italic opacity-50">Add description...</span>';
+            textSpan.setAttribute('title', currentDesc);
+            textSpan.setAttribute('data-desc', currentDesc);
             alert('Failed to update description.');
           }
         }
+      } else {
+        // Revert input value if cancelled
+        inputEl.value = textSpan.getAttribute('data-desc') || '';
+      }
+    };
+
+    textSpan.addEventListener('click', startEditing);
+    editBtn.addEventListener('click', startEditing);
+    
+    inputEl.addEventListener('blur', () => stopEditing(true));
+    inputEl.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        stopEditing(true);
+      } else if (e.key === 'Escape') {
+        stopEditing(false);
       }
     });
   });

--- a/src/ravioli/frontend/src/components/Data.ts
+++ b/src/ravioli/frontend/src/components/Data.ts
@@ -16,12 +16,18 @@ export function renderData() {
 
       <!-- Upload Zone -->
       <div class="mb-12">
-        <div id="drop-zone" class="border-2 border-dashed border-outline/30 rounded-3xl p-12 flex flex-col items-center justify-center bg-surface-container-low hover:bg-surface-container hover:border-primary/50 transition-all cursor-pointer group">
-          <div class="w-16 h-16 rounded-2xl bg-primary/10 flex items-center justify-center mb-6 group-hover:scale-110 transition-transform">
-            <span class="material-symbols-outlined text-primary text-3xl">upload_file</span>
+        <div id="drop-zone" class="border-2 border-dashed border-outline/30 rounded-3xl p-12 flex flex-col items-center justify-center bg-surface-container-low hover:bg-surface-container hover:border-primary/50 transition-all cursor-pointer group relative overflow-hidden">
+          <div id="drop-zone-content" class="flex flex-col items-center justify-center transition-opacity duration-300 w-full h-full">
+            <div class="w-16 h-16 rounded-2xl bg-primary/10 flex items-center justify-center mb-6 group-hover:scale-110 transition-transform">
+              <span class="material-symbols-outlined text-primary text-3xl">upload_file</span>
+            </div>
+            <h3 class="text-xl font-medium text-neutral-200 mb-2">Drop your CSV here</h3>
+            <p class="text-neutral-500 text-sm">or click to browse your files</p>
           </div>
-          <h3 class="text-xl font-medium text-neutral-200 mb-2">Drop your CSV here</h3>
-          <p class="text-neutral-500 text-sm">or click to browse your files</p>
+          <div id="drop-zone-loading" class="absolute inset-0 flex flex-col items-center justify-center bg-surface-container/90 backdrop-blur-sm opacity-0 pointer-events-none transition-opacity duration-300 z-10">
+            <span class="material-symbols-outlined animate-spin text-primary text-4xl mb-4">sync</span>
+            <p class="text-neutral-200 font-medium animate-pulse">Uploading and processing...</p>
+          </div>
           <input type="file" id="file-input" class="hidden" accept=".csv">
         </div>
       </div>
@@ -182,6 +188,15 @@ export function renderData() {
   });
 
   async function handleUpload(file: File) {
+    const dropZoneContent = container.querySelector('#drop-zone-content');
+    const dropZoneLoading = container.querySelector('#drop-zone-loading');
+    
+    // Show loading state
+    if (dropZoneContent && dropZoneLoading) {
+      dropZoneContent.classList.add('opacity-0');
+      dropZoneLoading.classList.remove('opacity-0', 'pointer-events-none');
+    }
+
     try {
       const result = await api.uploadFile(file);
       
@@ -194,6 +209,12 @@ export function renderData() {
     } catch (err) {
       console.error('Upload failed', err);
       alert('Upload failed. Please check the console for details.');
+    } finally {
+      // Hide loading state
+      if (dropZoneContent && dropZoneLoading) {
+        dropZoneContent.classList.remove('opacity-0');
+        dropZoneLoading.classList.add('opacity-0', 'pointer-events-none');
+      }
     }
   }
 

--- a/src/ravioli/frontend/src/components/Data.ts
+++ b/src/ravioli/frontend/src/components/Data.ts
@@ -44,6 +44,7 @@ export function renderData() {
             <thead>
               <tr class="text-[10px] uppercase tracking-[0.2em] text-neutral-500 border-b border-outline/5">
                 <th class="px-8 py-4 font-medium">Asset Name</th>
+                <th class="px-8 py-4 font-medium">Description</th>
                 <th class="px-8 py-4 font-medium">DuckDB Table</th>
                 <th class="px-8 py-4 font-medium">Rows</th>
                 <th class="px-8 py-4 font-medium">Size</th>
@@ -64,6 +65,14 @@ export function renderData() {
                         <span class="material-symbols-outlined text-neutral-400 group-hover:text-primary transition-colors text-lg">description</span>
                       </div>
                       <span class="text-neutral-200 font-medium">${file.original_filename}</span>
+                    </div>
+                  </td>
+                  <td class="px-8 py-5">
+                    <div class="flex items-center gap-2 group/desc max-w-xs">
+                      <span class="text-neutral-400 text-sm truncate" title="${file.description || ''}">${file.description || '<span class="italic opacity-50">No description</span>'}</span>
+                      <button class="btn-edit-desc p-1 rounded-md opacity-0 group-hover/desc:opacity-100 hover:bg-white/10 text-neutral-500 hover:text-primary transition-all flex-shrink-0" data-id="${file.id}" data-desc="${file.description || ''}" title="Edit Description">
+                        <span class="material-symbols-outlined text-[16px]">edit</span>
+                      </button>
                     </div>
                   </td>
                   <td class="px-8 py-5">
@@ -177,6 +186,26 @@ export function renderData() {
         } catch (err) {
           console.error('Delete failed', err);
           alert('Failed to delete file.');
+        }
+      }
+    });
+  });
+
+  container.querySelectorAll('.btn-edit-desc').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const fileId = btn.getAttribute('data-id');
+      const currentDesc = btn.getAttribute('data-desc') || '';
+      if (fileId) {
+        const newDesc = prompt('Enter a description for this data:', currentDesc);
+        if (newDesc !== null && newDesc !== currentDesc) {
+          try {
+            await api.updateFileDescription(fileId, newDesc);
+            const updatedFiles = await api.listFiles();
+            store.setUploadedFiles(updatedFiles);
+          } catch (err) {
+            console.error('Update description failed', err);
+            alert('Failed to update description.');
+          }
         }
       }
     });

--- a/src/ravioli/frontend/src/components/Data.ts
+++ b/src/ravioli/frontend/src/components/Data.ts
@@ -78,9 +78,12 @@ export function renderData() {
                       ${file.status}
                     </span>
                   </td>
-                  <td class="px-8 py-5 text-right">
-                    <button class="btn-inspect p-2 rounded-lg hover:bg-primary/10 text-neutral-400 hover:text-primary transition-all" data-table="${file.table_name}" data-filename="${file.original_filename}">
+                  <td class="px-8 py-5 text-right flex justify-end gap-2">
+                    <button class="btn-inspect p-2 rounded-lg hover:bg-primary/10 text-neutral-400 hover:text-primary transition-all" data-table="${file.table_name}" data-filename="${file.original_filename}" title="Preview">
                       <span class="material-symbols-outlined">visibility</span>
+                    </button>
+                    <button class="btn-delete p-2 rounded-lg hover:bg-red-500/10 text-neutral-400 hover:text-red-400 transition-all" data-id="${file.id}" title="Delete">
+                      <span class="material-symbols-outlined">delete</span>
                     </button>
                   </td>
                 </tr>
@@ -157,6 +160,22 @@ export function renderData() {
     });
   });
 
+  container.querySelectorAll('.btn-delete').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const fileId = btn.getAttribute('data-id');
+      if (fileId && confirm('Are you sure you want to delete this data? This will remove it from DuckDB and cannot be undone.')) {
+        try {
+          await api.deleteFile(fileId);
+          const updatedFiles = await api.listFiles();
+          store.setUploadedFiles(updatedFiles);
+        } catch (err) {
+          console.error('Delete failed', err);
+          alert('Failed to delete file.');
+        }
+      }
+    });
+  });
+
   closeModal?.addEventListener('click', () => hideModal());
   modal.addEventListener('click', (e) => {
     if (e.target === modal) hideModal();
@@ -164,7 +183,12 @@ export function renderData() {
 
   async function handleUpload(file: File) {
     try {
-      await api.uploadFile(file);
+      const result = await api.uploadFile(file);
+      
+      if (result.is_duplicate) {
+        alert(`Duplicate Data Detected: "${file.name}" has already been uploaded and processed. We've skipped the duplicate effort for you!`);
+      }
+
       const updatedFiles = await api.listFiles();
       store.setUploadedFiles(updatedFiles);
     } catch (err) {

--- a/src/ravioli/frontend/src/main.ts
+++ b/src/ravioli/frontend/src/main.ts
@@ -40,7 +40,7 @@ async function init() {
       console.log(`Fetched ${analyses.length} analyses from API`);
       store.setAnalyses(analyses);
       if (analyses.length > 0 && !store.getActiveAnalysisId()) {
-        store.setActiveAnalysisId(analyses[0].id);
+        // Removed auto-selecting the first analysis to default to the Dashboard tab
       }
     } catch (err) {
       console.error('Failed to fetch analyses', err);

--- a/src/ravioli/frontend/src/services/api.ts
+++ b/src/ravioli/frontend/src/services/api.ts
@@ -82,5 +82,15 @@ export const api = {
       method: 'DELETE',
     });
     if (!response.ok) throw new Error('Failed to delete file');
+  },
+
+  async updateFileDescription(fileId: string, description: string): Promise<UploadedFile> {
+    const response = await fetch(`${API_BASE}/data/files/${fileId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description }),
+    });
+    if (!response.ok) throw new Error('Failed to update file description');
+    return response.json();
   }
 };

--- a/src/ravioli/frontend/src/services/api.ts
+++ b/src/ravioli/frontend/src/services/api.ts
@@ -75,5 +75,12 @@ export const api = {
     const response = await fetch(`${API_BASE}/data/preview/${tableName}`);
     if (!response.ok) throw new Error('Failed to fetch preview');
     return response.json();
+  },
+
+  async deleteFile(fileId: string): Promise<void> {
+    const response = await fetch(`${API_BASE}/data/files/${fileId}`, {
+      method: 'DELETE',
+    });
+    if (!response.ok) throw new Error('Failed to delete file');
   }
 };

--- a/src/ravioli/frontend/src/types/index.ts
+++ b/src/ravioli/frontend/src/types/index.ts
@@ -34,6 +34,8 @@ export interface UploadedFile {
   row_count?: number;
   status: string;
   error_message?: string;
+  file_hash?: string;
+  is_duplicate?: boolean;
   created_at: string;
   updated_at: string;
 }

--- a/src/ravioli/frontend/src/utils/formatters.ts
+++ b/src/ravioli/frontend/src/utils/formatters.ts
@@ -1,0 +1,8 @@
+export function formatBytes(bytes: number, decimals = 1): string {
+  if (!+bytes) return '0 Bytes';
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+}

--- a/src/ravioli/frontend/tests/formatters.test.ts
+++ b/src/ravioli/frontend/tests/formatters.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { formatBytes } from '../src/utils/formatters';
+
+describe('formatBytes', () => {
+  it('formats zero bytes correctly', () => {
+    expect(formatBytes(0)).toBe('0 Bytes');
+  });
+
+  it('formats bytes correctly', () => {
+    expect(formatBytes(500)).toBe('500 Bytes');
+  });
+
+  it('formats KB correctly', () => {
+    expect(formatBytes(1024)).toBe('1 KB');
+    expect(formatBytes(1536)).toBe('1.5 KB');
+  });
+
+  it('formats MB correctly', () => {
+    expect(formatBytes(1048576)).toBe('1 MB');
+    expect(formatBytes(2569011)).toBe('2.4 MB'); // 2569011 / (1024 * 1024) = 2.4499... -> 2.4
+  });
+
+  it('formats GB correctly', () => {
+    expect(formatBytes(1073741824)).toBe('1 GB');
+    expect(formatBytes(5905580032)).toBe('5.5 GB'); // 5.5 * 1024^3
+  });
+
+  it('respects decimals parameter', () => {
+    expect(formatBytes(1536, 0)).toBe('2 KB'); // Math.round because of toFixed(0)
+    expect(formatBytes(1536, 2)).toBe('1.5 KB'); // toFixed(2) but parseFloat removes trailing zeros
+    expect(formatBytes(1540, 2)).toBe('1.5 KB'); // 1540 / 1024 = 1.5039... -> 1.5
+    expect(formatBytes(1550, 2)).toBe('1.51 KB'); // 1550 / 1024 = 1.5136... -> 1.51
+  });
+});

--- a/src/ravioli/frontend/vite.config.ts
+++ b/src/ravioli/frontend/vite.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
   plugins: [
     tailwindcss(),
   ],
+  resolve: {
+    alias: {
+      'postcss': path.resolve(__dirname, 'node_modules/postcss'),
+      '@tailwindcss/postcss': path.resolve(__dirname, 'node_modules/@tailwindcss/postcss')
+    }
+  },
   server: {
     proxy: {
       '/api': {

--- a/tests/ravioli/frontend/formatters.test.ts
+++ b/tests/ravioli/frontend/formatters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatBytes } from '../src/utils/formatters';
+import { formatBytes } from '../../../src/ravioli/frontend/src/utils/formatters';
 
 describe('formatBytes', () => {
   it('formats zero bytes correctly', () => {

--- a/tests/ravioli/frontend/postcss.test.ts
+++ b/tests/ravioli/frontend/postcss.test.ts
@@ -24,7 +24,7 @@ describe('PostCSS Configuration', () => {
 
   it('should be able to load the actual postcss.config.js', async () => {
     // This is a more direct test of the configuration file itself
-    const configPath = '../postcss.config.js';
+    const configPath = '../../../src/ravioli/frontend/postcss.config.js';
     const config = await import(configPath);
     
     expect(config.default).toBeDefined();

--- a/tests/ravioli/frontend/syntax.test.ts
+++ b/tests/ravioli/frontend/syntax.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { api } from '../src/services/api';
+import { api } from '../../../src/ravioli/frontend/src/services/api';
 
 test('api service is syntactically valid and exportable', () => {
   expect(api).toBeDefined();


### PR DESCRIPTION
# Description
This PR is meant to:
1. Add a duplicated manual data upload check based on hash. skipping the upload if it is deteced to be duplication
2. add a small animation when uploading the flat file
3. adjust tests

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass **locally** with my changes
- [x] I have made corresponding changes to the documentation (i.e. `README.md` files)
- [ ] I have commented my code, particularly in hard-to-understand areas