### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/AI-Passione/ravioli/security/code-scanning/2](https://github.com/AI-Passione/ravioli/security/code-scanning/2)

Add an explicit workflow-level `permissions` block so all jobs inherit least-privilege token access without changing current behavior.

Best fix here: in `.github/workflows/ci.yml`, insert at the top level (after `on:` block and before `jobs:`) the following:

- `permissions:`
  - `contents: read`

This satisfies CodeQL’s requirement and keeps functionality unchanged for the shown jobs. No imports, methods, or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
