### PR TITLE
Potential fix for code scanning alert no. 14: Information exposure through an exception

### DIFF
--- a/src/ravioli/backend/api/v1/endpoints/data.py
+++ b/src/ravioli/backend/api/v1/endpoints/data.py
@@ -703,7 +703,7 @@ async def upload_file_stream(
                 yield f"data: DONE:{json.dumps(result_dict)}\n\n"
             except Exception as e:
                 logger.exception(f"Error during upload_file_stream ingestion task for {file.filename}")
-                yield f"data: ERROR:An internal error occurred: {str(e)}\n\n"
+                yield "data: ERROR:An internal error occurred.\n\n"
                 
         finally:
             root_logger = logging.getLogger()


### PR DESCRIPTION
Potential fix for [https://github.com/AI-Passione/ravioli/security/code-scanning/14](https://github.com/AI-Passione/ravioli/security/code-scanning/14)

The correct fix is to stop including `str(e)` in the SSE payload sent to clients, and instead return a generic error message. Keep `logger.exception(...)` so full diagnostic details (including traceback) remain available in server logs.

Best minimal change (without altering functionality beyond exposure reduction):
- In `src/ravioli/backend/api/v1/endpoints/data.py`, inside `event_generator()` at the `except Exception as e:` block around lines 704–706:
  - Keep the logging call.
  - Replace the yielded error line to avoid interpolating exception text.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
