### PR TITLE
fix: fix pushing data from local DuckDB to remote Motherduck

### DIFF
--- a/src/ravioli/backend/api/v1/endpoints/settings.py
+++ b/src/ravioli/backend/api/v1/endpoints/settings.py
@@ -67,15 +67,34 @@ async def push_all_to_motherduck(db: Session = Depends(get_db)):
     stmt = select(DataSource).where(DataSource.has_pii == False)
     sources = db.execute(stmt).scalars().all()
     
-    results = []
+    tables_to_push = []
     for source in sources:
-        if not source.table_name: continue
+        if source.schema_name and source.table_name:
+            tables_to_push.append((source.schema_name, source.table_name))
+            
+    results = []
+    if tables_to_push:
         try:
-            duckdb_manager.sync_table(source.schema_name, source.table_name, direction="push")
-            results.append({"table": f"{source.schema_name}.{source.table_name}", "status": "success"})
+            # Trigger our optimized bulk block-level database copy push
+            duckdb_manager.push_all_non_pii(tables_to_push)
+            
+            # Verify which tables were copied
+            for schema, table in tables_to_push:
+                try:
+                    exists = duckdb_manager.connection.execute(
+                        f"SELECT count(*) FROM information_schema.tables "
+                        f"WHERE table_schema='{schema}' AND table_name='{table}'"
+                    ).fetchone()[0] > 0
+                except Exception:
+                    exists = False
+                
+                if exists:
+                    results.append({"table": f"{schema}.{table}", "status": "success"})
+                else:
+                    results.append({"table": f"{schema}.{table}", "status": "skipped", "error": "Table does not exist locally"})
         except Exception as e:
-            logger.error(f"Failed to push {source.table_name}: {e}")
-            results.append({"table": f"{source.schema_name}.{source.table_name}", "status": "failed", "error": str(e)})
+            logger.error(f"Failed to push tables in bulk: {e}")
+            raise HTTPException(status_code=500, detail=f"Bulk push to Motherduck failed: {str(e)}")
             
     logger.info(f"=== PUSH ALL COMPLETED ({len(results)} tables processed) ===")
     return {"status": "completed", "results": results}

--- a/src/ravioli/backend/data/olap/duckdb_manager.py
+++ b/src/ravioli/backend/data/olap/duckdb_manager.py
@@ -134,27 +134,38 @@ class DuckDBManager:
     def _get_remote_db_name(self):
         """Find the name of the attached Motherduck database."""
         try:
-            res = self.connection.execute("PRAGMA show_databases").fetchall()
-            # 1. Look for 'ravioli' (our preferred dedicated db)
+            res = self.connection.execute(
+                "SELECT database_name, path, type FROM duckdb_databases()"
+            ).fetchall()
+            # 1. Look for 'ravioli' (our preferred dedicated db) that is actually a Motherduck database
             for row in res:
-                if row[0] == 'ravioli':
+                db_name = row[0]
+                path = row[1] if len(row) > 1 else None
+                db_type = row[2] if len(row) > 2 else None
+                
+                if db_name == 'ravioli' and (db_type == 'motherduck' or (path and str(path).lower().startswith('md:'))):
                     return 'ravioli'
             
             # 2. Look for 'motherduck' alias
             for row in res:
-                if row[0] == 'motherduck':
+                db_name = row[0]
+                path = row[1] if len(row) > 1 else None
+                db_type = row[2] if len(row) > 2 else None
+                
+                if db_name == 'motherduck' and (db_type == 'motherduck' or (path and str(path).lower().startswith('md:'))):
                     return 'motherduck'
             
-            # 3. If no preferred names, look for the first non-standard database
-            # Standard: 'main', 'temp', 'system'
-            remote_name = 'motherduck'
+            # 3. If no preferred names, look for the first non-standard Motherduck database
             for row in res:
-                if row[0] not in ('main', 'temp', 'system', 'memory'):
-                    remote_name = row[0]
-                    break
+                db_name = row[0]
+                path = row[1] if len(row) > 1 else None
+                db_type = row[2] if len(row) > 2 else None
+                
+                if db_type == 'motherduck' or (path and str(path).lower().startswith('md:')):
+                    return db_name
             
-            logger.info(f"Using Motherduck remote database: {remote_name}")
-            return remote_name
+            logger.info("Using default Motherduck remote database name: motherduck")
+            return 'motherduck'
         except Exception as e:
             logger.error(f"Error finding remote db name: {e}")
             return 'motherduck'
@@ -162,7 +173,7 @@ class DuckDBManager:
     def reconnect(self):
         """
         Close existing connection and force a new one on next access.
-        Used when settings change.
+        Used when settings change or connection state gets corrupted.
         """
         if self._connection:
             try:
@@ -201,17 +212,42 @@ class DuckDBManager:
     def is_motherduck_connected(self):
         """Check if Motherduck database is attached."""
         try:
-            res = self.connection.execute("PRAGMA show_databases").fetchall()
-            # Verify it's actually a Motherduck connection by checking for 'md:' prefix 
-            # or 'ravioli' name (our specific alias)
+            res = self.connection.execute(
+                "SELECT database_name, path, type FROM duckdb_databases()"
+            ).fetchall()
             for row in res:
-                if row[0] in ('ravioli', 'motherduck'):
+                db_name = row[0]
+                path = row[1] if len(row) > 1 else None
+                db_type = row[2] if len(row) > 2 else None
+                
+                if db_type == 'motherduck' or (path and str(path).lower().startswith('md:')):
                     return True
-                if len(row) > 1 and str(row[1]).startswith('md:'):
+                # Legacy / mock testing support
+                if db_name == 'motherduck':
                     return True
             return False
-        except Exception:
-            return False
+        except Exception as e:
+            logger.warning(f"Error checking Motherduck connection, attempting reconnect: {e}")
+            try:
+                # Force close and clear the connection to heal stale/broken state (e.g. remotely dropped databases)
+                self.reconnect()
+                res = self.connection.execute(
+                    "SELECT database_name, path, type FROM duckdb_databases()"
+                ).fetchall()
+                for row in res:
+                    db_name = row[0]
+                    path = row[1] if len(row) > 1 else None
+                    db_type = row[2] if len(row) > 2 else None
+                    
+                    if db_type == 'motherduck' or (path and str(path).lower().startswith('md:')):
+                        return True
+                    # Legacy / mock testing support
+                    if db_name == 'motherduck':
+                        return True
+                return False
+            except Exception as reconnect_err:
+                logger.error(f"Automatic Motherduck reconnection healing failed: {reconnect_err}")
+                return False
 
     def get_table_diff(self, schema: str, table: str):
         """Calculate diff between local and remote Motherduck table."""

--- a/src/ravioli/backend/data/olap/duckdb_manager.py
+++ b/src/ravioli/backend/data/olap/duckdb_manager.py
@@ -342,8 +342,8 @@ class DuckDBManager:
                     f"SELECT * FROM \"{schema}\".\"{table}\""
                 )
 
-            # 3. Detach the temporary database to flush all changes to disk
-            self.connection.execute("DETACH temp_clean_db")
+            # 3. Switch default database context to temp_clean_db to allow detaching/replacing the primary 'ravioli' database
+            self.connection.execute("USE temp_clean_db")
 
             # 4. Push the temporary database file directly to Motherduck in a single block upload
             remote_db = self._get_remote_db_name()
@@ -351,8 +351,31 @@ class DuckDBManager:
             self.connection.execute(f"CREATE OR REPLACE DATABASE \"{remote_db}\" FROM '{temp_path}'")
             logger.info("MotherDuck Bulk Push: Success! Upload completed.")
 
+            # 5. Switch default database context back to the primary local/remote database
+            self.connection.execute(f"USE \"{remote_db}\"")
+
+            # 6. Detach the temporary database to flush all changes to disk
+            self.connection.execute("DETACH temp_clean_db")
+
         finally:
-            # 5. Always clean up the temporary file from the disk
+            # 7. Safely restore the primary database context if left switched
+            try:
+                current_db = self.connection.execute("SELECT current_database()").fetchone()[0]
+                if current_db == "temp_clean_db":
+                    remote_db = self._get_remote_db_name()
+                    self.connection.execute(f"USE \"{remote_db}\"")
+            except Exception as reset_err:
+                logger.warning(f"Could not restore default database context: {reset_err}")
+
+            # 8. Safely detach temp_clean_db if it is still attached
+            try:
+                attached_dbs = [row[0] for row in self.connection.execute("PRAGMA show_databases").fetchall()]
+                if "temp_clean_db" in attached_dbs:
+                    self.connection.execute("DETACH temp_clean_db")
+            except Exception as detach_err:
+                logger.warning(f"Could not detach temp_clean_db: {detach_err}")
+
+            # 9. Always clean up the temporary file from the disk
             if os.path.exists(temp_path):
                 try:
                     os.remove(temp_path)

--- a/src/ravioli/backend/data/olap/duckdb_manager.py
+++ b/src/ravioli/backend/data/olap/duckdb_manager.py
@@ -133,42 +133,8 @@ class DuckDBManager:
 
     def _get_remote_db_name(self):
         """Find the name of the attached Motherduck database."""
-        try:
-            res = self.connection.execute(
-                "SELECT database_name, path, type FROM duckdb_databases()"
-            ).fetchall()
-            # 1. Look for 'ravioli' (our preferred dedicated db) that is actually a Motherduck database
-            for row in res:
-                db_name = row[0]
-                path = row[1] if len(row) > 1 else None
-                db_type = row[2] if len(row) > 2 else None
-                
-                if db_name == 'ravioli' and (db_type == 'motherduck' or (path and str(path).lower().startswith('md:'))):
-                    return 'ravioli'
-            
-            # 2. Look for 'motherduck' alias
-            for row in res:
-                db_name = row[0]
-                path = row[1] if len(row) > 1 else None
-                db_type = row[2] if len(row) > 2 else None
-                
-                if db_name == 'motherduck' and (db_type == 'motherduck' or (path and str(path).lower().startswith('md:'))):
-                    return 'motherduck'
-            
-            # 3. If no preferred names, look for the first non-standard Motherduck database
-            for row in res:
-                db_name = row[0]
-                path = row[1] if len(row) > 1 else None
-                db_type = row[2] if len(row) > 2 else None
-                
-                if db_type == 'motherduck' or (path and str(path).lower().startswith('md:')):
-                    return db_name
-            
-            logger.info("Using default Motherduck remote database name: motherduck")
-            return 'motherduck'
-        except Exception as e:
-            logger.error(f"Error finding remote db name: {e}")
-            return 'motherduck'
+        # The canonical remote Motherduck database for our application is always 'ravioli'
+        return 'ravioli'
 
     def reconnect(self):
         """

--- a/src/ravioli/backend/data/olap/duckdb_manager.py
+++ b/src/ravioli/backend/data/olap/duckdb_manager.py
@@ -130,14 +130,21 @@ class DuckDBManager:
                             # Attach 'md:' workspace root if not already attached
                             try:
                                 self._connection.execute("ATTACH 'md:'")
-                            except Exception:
-                                pass
+                            except Exception as workspace_attach_err:
+                                logger.debug(
+                                    "Ignoring failure while attaching optional Motherduck workspace root 'md:' "
+                                    "during recreate flow: %s",
+                                    workspace_attach_err,
+                                )
                             
                             # Force recreate the remote database on Motherduck
                             try:
                                 self._connection.execute("DROP DATABASE IF EXISTS md:ravioli")
-                            except Exception:
-                                pass
+                            except Exception as drop_err:
+                                logger.debug(
+                                    "Ignoring non-fatal failure while dropping 'md:ravioli' during recreate flow: %s",
+                                    drop_err,
+                                )
                             self._connection.execute("CREATE DATABASE md:ravioli")
                             
                             # Try to attach again

--- a/src/ravioli/backend/data/olap/duckdb_manager.py
+++ b/src/ravioli/backend/data/olap/duckdb_manager.py
@@ -99,7 +99,8 @@ class DuckDBManager:
                         if "already attached" not in str(e).lower():
                             logger.error(f"Failed to attach workspace root: {e}")
                     
-                    self._connection.execute("CREATE DATABASE IF NOT EXISTS ravioli")
+                    # Use 'md:ravioli' to avoid local naming conflicts with local 'ravioli' catalog
+                    self._connection.execute("CREATE DATABASE IF NOT EXISTS md:ravioli")
                 except Exception as create_err:
                     logger.error(f"Creation of 'ravioli' database failed: {create_err}")
                 
@@ -117,8 +118,38 @@ class DuckDBManager:
                     
                     # Verify Identity & Context
                     id_info = self._connection.execute("SELECT current_user(), current_database()").fetchone()
-                    logger.info(f"Successfully attached! Cloud Identity: {id_info[0]} | Active DB: {id_info[1]}")
+                    if id_info and len(id_info) >= 2:
+                        logger.info(f"Successfully attached! Cloud Identity: {id_info[0]} | Active DB: {id_info[1]}")
+                    else:
+                        logger.info("Successfully attached to Motherduck!")
                 except Exception as attach_err:
+                    err_msg = str(attach_err).lower()
+                    if "deleted" in err_msg or "does not exist" in err_msg or "not found" in err_msg:
+                        logger.info("Motherduck remote database 'ravioli' was deleted or is missing. Recreating from scratch...")
+                        try:
+                            # Attach 'md:' workspace root if not already attached
+                            try:
+                                self._connection.execute("ATTACH 'md:'")
+                            except Exception:
+                                pass
+                            
+                            # Force recreate the remote database on Motherduck
+                            try:
+                                self._connection.execute("DROP DATABASE IF EXISTS md:ravioli")
+                            except Exception:
+                                pass
+                            self._connection.execute("CREATE DATABASE md:ravioli")
+                            
+                            # Try to attach again
+                            try:
+                                self._connection.execute("ATTACH 'md:ravioli' AS ravioli")
+                            except Exception:
+                                self._connection.execute("ATTACH 'md:ravioli'")
+                            logger.info("Successfully recreated and attached 'md:ravioli' from scratch!")
+                            return
+                        except Exception as recreate_err:
+                            logger.error(f"Failed to recreate Motherduck database from scratch: {recreate_err}")
+
                     if "already attached" not in str(attach_err).lower():
                         logger.error(f"Could not attach 'md:ravioli': {attach_err}")
                         # Final fallback

--- a/src/ravioli/backend/data/olap/duckdb_manager.py
+++ b/src/ravioli/backend/data/olap/duckdb_manager.py
@@ -339,7 +339,7 @@ class DuckDBManager:
                 # Copy table structure and data
                 self.connection.execute(
                     f"CREATE TABLE temp_clean_db.\"{schema}\".\"{table}\" AS "
-                    f"SELECT * FROM main.\"{schema}\".\"{table}\""
+                    f"SELECT * FROM \"{schema}\".\"{table}\""
                 )
 
             # 3. Detach the temporary database to flush all changes to disk

--- a/src/ravioli/backend/data/olap/duckdb_manager.py
+++ b/src/ravioli/backend/data/olap/duckdb_manager.py
@@ -296,5 +296,72 @@ class DuckDBManager:
         
         return self.get_table_diff(schema, table)
 
+    def push_all_non_pii(self, tables: list[tuple[str, str]]):
+        """
+        Create a temporary local DuckDB file containing only the selected non-PII tables,
+        and upload/push it to MotherDuck in a single, block-level operation.
+        """
+        if not self.is_motherduck_connected():
+            raise Exception("Motherduck not connected")
+
+        import tempfile
+        # Create a temporary file path inside the same directory as settings.duckdb_path
+        # to ensure it's on the same filesystem/volume and has write access
+        temp_dir = os.path.dirname(settings.duckdb_path)
+        os.makedirs(temp_dir, exist_ok=True)
+        
+        # We close the file right away so DuckDB can open it exclusively
+        temp_file = tempfile.NamedTemporaryFile(dir=temp_dir, suffix=".duckdb", delete=False)
+        temp_path = temp_file.name
+        temp_file.close()
+
+        try:
+            logger.info(f"MotherDuck Bulk Push: Creating sanitized local copy at {temp_path}...")
+            # 1. Attach the temporary database to our active connection
+            self.connection.execute(f"ATTACH '{temp_path}' AS temp_clean_db")
+
+            # 2. Replicate only the specified non-PII tables into the temp database
+            for schema, table in tables:
+                logger.info(f"MotherDuck Bulk Push: Exporting table \"{schema}\".\"{table}\"...")
+                # Verify that the table exists locally before attempting to copy
+                try:
+                    exists = self.connection.execute(
+                        f"SELECT count(*) FROM information_schema.tables "
+                        f"WHERE table_schema='{schema}' AND table_name='{table}'"
+                    ).fetchone()[0] > 0
+                except Exception as check_err:
+                    logger.warning(f"Error checking existence of {schema}.{table}: {check_err}")
+                    exists = False
+
+                if not exists:
+                    logger.warning(f"Table \"{schema}\".\"{table}\" does not exist in local DuckDB. Skipping.")
+                    continue
+
+                # Ensure the schema exists in the temp database
+                self.connection.execute(f"CREATE SCHEMA IF NOT EXISTS temp_clean_db.\"{schema}\"")
+                # Copy table structure and data
+                self.connection.execute(
+                    f"CREATE TABLE temp_clean_db.\"{schema}\".\"{table}\" AS "
+                    f"SELECT * FROM main.\"{schema}\".\"{table}\""
+                )
+
+            # 3. Detach the temporary database to flush all changes to disk
+            self.connection.execute("DETACH temp_clean_db")
+
+            # 4. Push the temporary database file directly to Motherduck in a single block upload
+            remote_db = self._get_remote_db_name()
+            logger.info(f"MotherDuck Bulk Push: Uploading copy to remote database '{remote_db}'...")
+            self.connection.execute(f"CREATE OR REPLACE DATABASE \"{remote_db}\" FROM '{temp_path}'")
+            logger.info("MotherDuck Bulk Push: Success! Upload completed.")
+
+        finally:
+            # 5. Always clean up the temporary file from the disk
+            if os.path.exists(temp_path):
+                try:
+                    os.remove(temp_path)
+                    logger.info("MotherDuck Bulk Push: Cleaned up temporary DuckDB file.")
+                except Exception as clean_err:
+                    logger.warning(f"Failed to remove temp DuckDB file {temp_path}: {clean_err}")
+
 duckdb_manager = DuckDBManager()
 data_ingestor = DataIngestor(duckdb_manager)

--- a/src/ravioli/backend/data/olap/duckdb_manager.py
+++ b/src/ravioli/backend/data/olap/duckdb_manager.py
@@ -342,32 +342,44 @@ class DuckDBManager:
                     f"SELECT * FROM \"{schema}\".\"{table}\""
                 )
 
-            # 3. Switch default database context to temp_clean_db to allow detaching/replacing the primary 'ravioli' database
-            self.connection.execute("USE temp_clean_db")
+            # 3. Detach the temporary database early to release file locks and avoid file handle conflicts
+            self.connection.execute("DETACH temp_clean_db")
 
-            # 4. Push the temporary database file directly to Motherduck in a single block upload
+            # 4. Attach a dummy in-memory database to allow detaching/replacing 'ravioli' (the default database)
+            self.connection.execute("ATTACH ':memory:' AS dummy_db")
+            self.connection.execute("USE dummy_db")
+
+            # 5. Push the temporary database file directly to Motherduck in a single block upload
             remote_db = self._get_remote_db_name()
             logger.info(f"MotherDuck Bulk Push: Uploading copy to remote database '{remote_db}'...")
             self.connection.execute(f"CREATE OR REPLACE DATABASE \"{remote_db}\" FROM '{temp_path}'")
             logger.info("MotherDuck Bulk Push: Success! Upload completed.")
 
-            # 5. Switch default database context back to the primary local/remote database
+            # 6. Switch default database context back to the primary local/remote database
             self.connection.execute(f"USE \"{remote_db}\"")
 
-            # 6. Detach the temporary database to flush all changes to disk
-            self.connection.execute("DETACH temp_clean_db")
+            # 7. Detach the dummy database
+            self.connection.execute("DETACH dummy_db")
 
         finally:
-            # 7. Safely restore the primary database context if left switched
+            # 8. Safely restore the primary database context if left switched
             try:
                 current_db = self.connection.execute("SELECT current_database()").fetchone()[0]
-                if current_db == "temp_clean_db":
+                if current_db in ("temp_clean_db", "dummy_db"):
                     remote_db = self._get_remote_db_name()
                     self.connection.execute(f"USE \"{remote_db}\"")
             except Exception as reset_err:
                 logger.warning(f"Could not restore default database context: {reset_err}")
 
-            # 8. Safely detach temp_clean_db if it is still attached
+            # 9. Safely detach dummy_db if it is still attached
+            try:
+                attached_dbs = [row[0] for row in self.connection.execute("PRAGMA show_databases").fetchall()]
+                if "dummy_db" in attached_dbs:
+                    self.connection.execute("DETACH dummy_db")
+            except Exception as detach_err:
+                logger.warning(f"Could not detach dummy_db: {detach_err}")
+
+            # 10. Safely detach temp_clean_db if it is still attached
             try:
                 attached_dbs = [row[0] for row in self.connection.execute("PRAGMA show_databases").fetchall()]
                 if "temp_clean_db" in attached_dbs:
@@ -375,7 +387,7 @@ class DuckDBManager:
             except Exception as detach_err:
                 logger.warning(f"Could not detach temp_clean_db: {detach_err}")
 
-            # 9. Always clean up the temporary file from the disk
+            # 11. Always clean up the temporary file from the disk
             if os.path.exists(temp_path):
                 try:
                     os.remove(temp_path)

--- a/src/ravioli/backend/data/olap/duckdb_manager.py
+++ b/src/ravioli/backend/data/olap/duckdb_manager.py
@@ -2,6 +2,8 @@ import duckdb
 import os
 import pandas as pd
 import logging
+import uuid
+
 from ravioli.backend.core.config import settings
 from ravioli.backend.core.database import SessionLocal
 from ravioli.backend.core.models import SystemSetting
@@ -304,16 +306,11 @@ class DuckDBManager:
         if not self.is_motherduck_connected():
             raise Exception("Motherduck not connected")
 
-        import tempfile
-        # Create a temporary file path inside the same directory as settings.duckdb_path
+        # Generate a unique non-existent temporary file path inside the same directory as settings.duckdb_path
         # to ensure it's on the same filesystem/volume and has write access
         temp_dir = os.path.dirname(settings.duckdb_path)
         os.makedirs(temp_dir, exist_ok=True)
-        
-        # We close the file right away so DuckDB can open it exclusively
-        temp_file = tempfile.NamedTemporaryFile(dir=temp_dir, suffix=".duckdb", delete=False)
-        temp_path = temp_file.name
-        temp_file.close()
+        temp_path = os.path.join(temp_dir, f"temp_{uuid.uuid4().hex}.duckdb")
 
         try:
             logger.info(f"MotherDuck Bulk Push: Creating sanitized local copy at {temp_path}...")

--- a/tests/ravioli/backend/api/v1/endpoints/test_settings.py
+++ b/tests/ravioli/backend/api/v1/endpoints/test_settings.py
@@ -191,3 +191,53 @@ async def test_test_ollama_connection_success(client, session, mocker):
     assert response.status_code == 200
     assert response.json()["status"] == "success"
     assert "Successfully connected" in response.json()["message"]
+
+def test_push_all_to_motherduck_success(client, session, mocker):
+    # Mock duckdb_manager
+    mock_duckdb = mocker.patch("ravioli.backend.api.v1.endpoints.settings.duckdb_manager")
+    mock_duckdb.is_motherduck_connected.return_value = True
+    mock_duckdb._get_remote_db_name.return_value = "ravioli"
+    mock_duckdb.push_all_non_pii = MagicMock()
+    
+    # Mock table existence check in local DuckDB (execute returns True for existence check)
+    mock_duckdb.connection.execute.return_value.fetchone.return_value = (1,)
+
+    # Mock DataSource query results
+    mock_source = DataSource(
+        id=uuid.uuid4(),
+        filename="test.csv",
+        original_filename="test.csv",
+        content_type="text/csv",
+        size_bytes=100,
+        table_name="test_table",
+        schema_name="s_manual",
+        status="completed",
+        source_type="file",
+        has_pii=False,
+        owner_type="user",
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        created_by=None,
+        updated_by=None,
+        owner=None,
+        owner_id=None
+    )
+    
+    mock_result = MagicMock()
+    session.execute.return_value = mock_result
+    mock_result.scalars.return_value.all.return_value = [mock_source]
+
+    # Import DataSource so we can mock its imports or use it directly
+    from ravioli.backend.core.models import DataSource
+
+    response = client.post("/api/v1/settings/motherduck/push")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "completed"
+    assert len(data["results"]) == 1
+    assert data["results"][0]["table"] == "s_manual.test_table"
+    assert data["results"][0]["status"] == "success"
+    
+    # Verify push_all_non_pii was called with correct parameters
+    mock_duckdb.push_all_non_pii.assert_called_once_with([("s_manual", "test_table")])

--- a/tests/ravioli/backend/api/v1/endpoints/test_settings.py
+++ b/tests/ravioli/backend/api/v1/endpoints/test_settings.py
@@ -193,8 +193,10 @@ async def test_test_ollama_connection_success(client, session, mocker):
     assert "Successfully connected" in response.json()["message"]
 
 def test_push_all_to_motherduck_success(client, session, mocker):
+    from ravioli.backend.core.models import DataSource
+
     # Mock duckdb_manager
-    mock_duckdb = mocker.patch("ravioli.backend.api.v1.endpoints.settings.duckdb_manager")
+    mock_duckdb = mocker.patch("ravioli.backend.data.olap.duckdb_manager.duckdb_manager")
     mock_duckdb.is_motherduck_connected.return_value = True
     mock_duckdb._get_remote_db_name.return_value = "ravioli"
     mock_duckdb.push_all_non_pii = MagicMock()
@@ -226,9 +228,6 @@ def test_push_all_to_motherduck_success(client, session, mocker):
     mock_result = MagicMock()
     session.execute.return_value = mock_result
     mock_result.scalars.return_value.all.return_value = [mock_source]
-
-    # Import DataSource so we can mock its imports or use it directly
-    from ravioli.backend.core.models import DataSource
 
     response = client.post("/api/v1/settings/motherduck/push")
 

--- a/tests/ravioli/backend/data/olap/test_duckdb_motherduck.py
+++ b/tests/ravioli/backend/data/olap/test_duckdb_motherduck.py
@@ -84,25 +84,28 @@ def test_push_all_non_pii(mock_duckdb):
                     (0,), # table2 exists check
                 ]
                 
-                # Mock NamedTemporaryFile
-                with patch("tempfile.NamedTemporaryFile") as mock_temp:
-                    mock_file = MagicMock()
-                    mock_file.name = "/mock/path/temp.duckdb"
-                    mock_temp.return_value = mock_file
-                    
+                # Mock uuid.uuid4().hex to return 'mockeduuid'
+                mock_uuid = MagicMock()
+                mock_uuid.hex = "mockeduuid"
+                with patch("uuid.uuid4", return_value=mock_uuid):
                     # Mock os.path.exists and os.remove
                     with patch("os.path.exists", return_value=True), patch("os.remove") as mock_remove:
+                        import os
+                        from ravioli.backend.core.config import settings
+                        temp_dir = os.path.dirname(settings.duckdb_path)
+                        expected_path = os.path.join(temp_dir, "temp_mockeduuid.duckdb")
+
                         tables = [("s_manual", "table1"), ("s_manual", "table2")]
                         manager.push_all_non_pii(tables)
                         
                         # Verify temporary file cleanup was triggered
-                        mock_remove.assert_called_once_with("/mock/path/temp.duckdb")
+                        mock_remove.assert_called_once_with(expected_path)
                         
                         # Verify executed queries
                         execute_calls = [call[0][0] for call in mock_duckdb.return_value.execute.call_args_list]
                         
                         # Verify we attached the temp db
-                        assert any("ATTACH '/mock/path/temp.duckdb' AS temp_clean_db" in cmd for cmd in execute_calls)
+                        assert any(f"ATTACH '{expected_path}' AS temp_clean_db" in cmd for cmd in execute_calls)
                         # Verify we checked existence of both tables
                         assert any("WHERE table_schema='s_manual' AND table_name='table1'" in cmd for cmd in execute_calls)
                         assert any("WHERE table_schema='s_manual' AND table_name='table2'" in cmd for cmd in execute_calls)
@@ -111,4 +114,4 @@ def test_push_all_non_pii(mock_duckdb):
                         assert not any("CREATE TABLE temp_clean_db.\"s_manual\".\"table2\"" in cmd for cmd in execute_calls)
                         # Verify detach and block push
                         assert any("DETACH temp_clean_db" in cmd for cmd in execute_calls)
-                        assert any("CREATE OR REPLACE DATABASE \"ravioli\" FROM '/mock/path/temp.duckdb'" in cmd for cmd in execute_calls)
+                        assert any(f"CREATE OR REPLACE DATABASE \"ravioli\" FROM '{expected_path}'" in cmd for cmd in execute_calls)

--- a/tests/ravioli/backend/data/olap/test_duckdb_motherduck.py
+++ b/tests/ravioli/backend/data/olap/test_duckdb_motherduck.py
@@ -78,11 +78,17 @@ def test_push_all_non_pii(mock_duckdb):
         with patch.object(manager, 'is_motherduck_connected', return_value=True):
             # Mock _get_remote_db_name to return 'ravioli'
             with patch.object(manager, '_get_remote_db_name', return_value='ravioli'):
-                # Mock table existence checks: table1 exists, table2 does not
-                mock_duckdb.return_value.execute.return_value.fetchone.side_effect = [
-                    (1,), # table1 exists check
-                    (0,), # table2 exists check
-                ]
+                # Mock table existence checks: table1 exists, table2 does not, and finally block queries
+                calls = []
+                def mock_fetchone():
+                    if len(calls) < 2:
+                        val = (1,) if len(calls) == 0 else (0,)
+                        calls.append(val)
+                        return val
+                    return ("ravioli",)
+                
+                mock_duckdb.return_value.execute.return_value.fetchone.side_effect = mock_fetchone
+                mock_duckdb.return_value.execute.return_value.fetchall.return_value = [("ravioli",)]
                 
                 # Mock uuid.uuid4().hex to return 'mockeduuid'
                 mock_uuid = MagicMock()

--- a/tests/ravioli/backend/data/olap/test_duckdb_motherduck.py
+++ b/tests/ravioli/backend/data/olap/test_duckdb_motherduck.py
@@ -67,3 +67,48 @@ def test_duckdb_manager_reconnect(mock_db_session, mock_duckdb, mock_decrypt):
         # mock_duckdb is the connect mock, so it should be called twice
         assert mock_duckdb.called
         assert mock_duckdb.call_count == 2
+
+def test_push_all_non_pii(mock_duckdb):
+    with patch.object(DuckDBManager, '_instance', None):
+        manager = DuckDBManager()
+        # Mock connection property to avoid attachment logic
+        manager._connection = mock_duckdb.return_value
+        
+        # Mock is_motherduck_connected to return True
+        with patch.object(manager, 'is_motherduck_connected', return_value=True):
+            # Mock _get_remote_db_name to return 'ravioli'
+            with patch.object(manager, '_get_remote_db_name', return_value='ravioli'):
+                # Mock table existence checks: table1 exists, table2 does not
+                mock_duckdb.return_value.execute.return_value.fetchone.side_effect = [
+                    (1,), # table1 exists check
+                    (0,), # table2 exists check
+                ]
+                
+                # Mock NamedTemporaryFile
+                with patch("tempfile.NamedTemporaryFile") as mock_temp:
+                    mock_file = MagicMock()
+                    mock_file.name = "/mock/path/temp.duckdb"
+                    mock_temp.return_value = mock_file
+                    
+                    # Mock os.path.exists and os.remove
+                    with patch("os.path.exists", return_value=True), patch("os.remove") as mock_remove:
+                        tables = [("s_manual", "table1"), ("s_manual", "table2")]
+                        manager.push_all_non_pii(tables)
+                        
+                        # Verify temporary file cleanup was triggered
+                        mock_remove.assert_called_once_with("/mock/path/temp.duckdb")
+                        
+                        # Verify executed queries
+                        execute_calls = [call[0][0] for call in mock_duckdb.return_value.execute.call_args_list]
+                        
+                        # Verify we attached the temp db
+                        assert any("ATTACH '/mock/path/temp.duckdb' AS temp_clean_db" in cmd for cmd in execute_calls)
+                        # Verify we checked existence of both tables
+                        assert any("WHERE table_schema='s_manual' AND table_name='table1'" in cmd for cmd in execute_calls)
+                        assert any("WHERE table_schema='s_manual' AND table_name='table2'" in cmd for cmd in execute_calls)
+                        # Verify table1 was copied, but table2 was skipped
+                        assert any("CREATE TABLE temp_clean_db.\"s_manual\".\"table1\"" in cmd for cmd in execute_calls)
+                        assert not any("CREATE TABLE temp_clean_db.\"s_manual\".\"table2\"" in cmd for cmd in execute_calls)
+                        # Verify detach and block push
+                        assert any("DETACH temp_clean_db" in cmd for cmd in execute_calls)
+                        assert any("CREATE OR REPLACE DATABASE \"ravioli\" FROM '/mock/path/temp.duckdb'" in cmd for cmd in execute_calls)

--- a/tests/ravioli/backend/data/olap/test_duckdb_motherduck.py
+++ b/tests/ravioli/backend/data/olap/test_duckdb_motherduck.py
@@ -121,3 +121,8 @@ def test_push_all_non_pii(mock_duckdb):
                         # Verify detach and block push
                         assert any("DETACH temp_clean_db" in cmd for cmd in execute_calls)
                         assert any(f"CREATE OR REPLACE DATABASE \"ravioli\" FROM '{expected_path}'" in cmd for cmd in execute_calls)
+                        # Verify dummy database lifecycle switching
+                        assert any("ATTACH ':memory:' AS dummy_db" in cmd for cmd in execute_calls)
+                        assert any("USE dummy_db" in cmd for cmd in execute_calls)
+                        assert any("USE \"ravioli\"" in cmd for cmd in execute_calls)
+                        assert any("DETACH dummy_db" in cmd for cmd in execute_calls)


### PR DESCRIPTION
# Description
This PR is meant to:
1. fix the data pushing from local DuckDB to remote Motherduck (first create local copy of non-PII data, then push)
2. adjust tests


# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass **locally** with my changes
- [ ] I have made corresponding changes to the documentation (i.e. `README.md` files)
- [ ] I have commented my code, particularly in hard-to-understand areas