### PR TITLE
feat: show Ownership of Insights, Knowledge, and Data Sources in frontend

### DIFF
--- a/src/ravioli/backend/api/v1/endpoints/data.py
+++ b/src/ravioli/backend/api/v1/endpoints/data.py
@@ -330,7 +330,11 @@ async def upload_file(
 
 @router.get("/files", response_model=List[schemas.DataSource])
 async def list_files(db: Session = Depends(get_db)):
-    query = select(DataSource).order_by(DataSource.created_at.desc())
+    query = select(DataSource).options(
+        joinedload(DataSource.owner_user),
+        joinedload(DataSource.owner_group),
+        joinedload(DataSource.creator_user)
+    ).order_by(DataSource.created_at.desc())
     result = db.execute(query)
     return result.scalars().all()
 

--- a/src/ravioli/backend/api/v1/endpoints/insights.py
+++ b/src/ravioli/backend/api/v1/endpoints/insights.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import func
 from typing import List
 from uuid import UUID
@@ -65,6 +65,12 @@ def get_review_queue(db: Session = Depends(get_db)):
     """Unverified insights awaiting operator review, newest first."""
     return (
         db.query(models.Insight)
+        .options(
+            joinedload(models.Insight.owner_user),
+            joinedload(models.Insight.owner_group),
+            joinedload(models.Insight.creator_user),
+            joinedload(models.Insight.reviewer_user)
+        )
         .filter(models.Insight.is_verified == False)
         .order_by(models.Insight.created_at.desc())
         .all()
@@ -77,6 +83,12 @@ def get_insights_feed(days: int = 30, db: Session = Depends(get_db)):
     since = datetime.now(UTC) - timedelta(days=days)
     return (
         db.query(models.Insight)
+        .options(
+            joinedload(models.Insight.owner_user),
+            joinedload(models.Insight.owner_group),
+            joinedload(models.Insight.creator_user),
+            joinedload(models.Insight.reviewer_user)
+        )
         .filter(models.Insight.is_verified == True, models.Insight.created_at >= since)
         .order_by(models.Insight.created_at.desc())
         .all()
@@ -96,9 +108,17 @@ def verify_insight(
     insight.is_verified = True
     insight.updated_at = datetime.now(UTC)
     insight.updated_by = current_user.id
+    insight.reviewed_by = current_user.id
     db.commit()
     db.refresh(insight)
-    return insight
+    
+    # Return with eager loaded relations
+    return db.query(models.Insight).options(
+        joinedload(models.Insight.owner_user),
+        joinedload(models.Insight.owner_group),
+        joinedload(models.Insight.creator_user),
+        joinedload(models.Insight.reviewer_user)
+    ).filter(models.Insight.id == insight_id).first()
 
 
 @router.patch("/{insight_id}/reject", response_model=schemas.Insight)
@@ -114,4 +134,9 @@ def reject_insight(insight_id: UUID, db: Session = Depends(get_db)):
 
 @router.get("/", response_model=List[schemas.Insight])
 def list_insights(db: Session = Depends(get_db)):
-    return db.query(models.Insight).order_by(models.Insight.created_at.desc()).all()
+    return db.query(models.Insight).options(
+        joinedload(models.Insight.owner_user),
+        joinedload(models.Insight.owner_group),
+        joinedload(models.Insight.creator_user),
+        joinedload(models.Insight.reviewer_user)
+    ).order_by(models.Insight.created_at.desc()).all()

--- a/src/ravioli/backend/api/v1/endpoints/knowledge.py
+++ b/src/ravioli/backend/api/v1/endpoints/knowledge.py
@@ -1,6 +1,6 @@
 from typing import List
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from uuid import UUID
 
 from ravioli.backend.core import models, schemas
@@ -12,7 +12,12 @@ router = APIRouter()
 @router.get("/", response_model=List[schemas.KnowledgePage])
 def list_knowledge_pages(db: Session = Depends(get_db)):
     """List all knowledge pages."""
-    return db.query(models.KnowledgePage).order_by(models.KnowledgePage.updated_at.desc()).all()
+    return db.query(models.KnowledgePage).options(
+        joinedload(models.KnowledgePage.owner_user),
+        joinedload(models.KnowledgePage.owner_group),
+        joinedload(models.KnowledgePage.creator_user),
+        joinedload(models.KnowledgePage.reviewer_user)
+    ).order_by(models.KnowledgePage.updated_at.desc()).all()
 
 @router.post("/", response_model=schemas.KnowledgePage, status_code=status.HTTP_201_CREATED)
 def create_knowledge_page(
@@ -25,17 +30,29 @@ def create_knowledge_page(
         **page.model_dump(exclude={"owner"}),
         owner=page.owner or current_user.id,
         created_by=current_user.id,
-        updated_by=current_user.id
+        updated_by=current_user.id,
+        reviewed_by=current_user.id if current_user.role == "Admin" else None
     )
     db.add(db_page)
     db.commit()
     db.refresh(db_page)
-    return db_page
+    
+    return db.query(models.KnowledgePage).options(
+        joinedload(models.KnowledgePage.owner_user),
+        joinedload(models.KnowledgePage.owner_group),
+        joinedload(models.KnowledgePage.creator_user),
+        joinedload(models.KnowledgePage.reviewer_user)
+    ).filter(models.KnowledgePage.id == db_page.id).first()
 
 @router.get("/{page_id}", response_model=schemas.KnowledgePage)
 def get_knowledge_page(page_id: UUID, db: Session = Depends(get_db)):
     """Get a knowledge page by ID."""
-    page = db.query(models.KnowledgePage).filter(models.KnowledgePage.id == page_id).first()
+    page = db.query(models.KnowledgePage).options(
+        joinedload(models.KnowledgePage.owner_user),
+        joinedload(models.KnowledgePage.owner_group),
+        joinedload(models.KnowledgePage.creator_user),
+        joinedload(models.KnowledgePage.reviewer_user)
+    ).filter(models.KnowledgePage.id == page_id).first()
     if not page:
         raise HTTPException(status_code=404, detail="Knowledge page not found")
     return page
@@ -57,9 +74,17 @@ def update_knowledge_page(
         setattr(db_page, key, value)
     
     db_page.updated_by = current_user.id
+    if current_user.role == "Admin":
+        db_page.reviewed_by = current_user.id
     db.commit()
     db.refresh(db_page)
-    return db_page
+    
+    return db.query(models.KnowledgePage).options(
+        joinedload(models.KnowledgePage.owner_user),
+        joinedload(models.KnowledgePage.owner_group),
+        joinedload(models.KnowledgePage.creator_user),
+        joinedload(models.KnowledgePage.reviewer_user)
+    ).filter(models.KnowledgePage.id == page_id).first()
 
 @router.delete("/{page_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_knowledge_page(page_id: UUID, db: Session = Depends(get_db)):

--- a/src/ravioli/backend/core/models.py
+++ b/src/ravioli/backend/core/models.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, UTC
 from typing import Optional, List
-from sqlalchemy import String, DateTime, JSON, ForeignKey, Text, Boolean, cast
+from sqlalchemy import String, DateTime, JSON, ForeignKey, Text, Boolean
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 from ravioli.backend.core.database import Base

--- a/src/ravioli/backend/core/models.py
+++ b/src/ravioli/backend/core/models.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, UTC
 from typing import Optional, List
-from sqlalchemy import String, DateTime, JSON, ForeignKey, Text, Boolean
+from sqlalchemy import String, DateTime, JSON, ForeignKey, Text, Boolean, cast
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 from ravioli.backend.core.database import Base
@@ -163,6 +163,8 @@ class DataSource(Base):
     owner_type: Mapped[Optional[str]] = mapped_column(String(50), default="user") # 'user' or 'group'
     
     owner_user: Mapped[Optional["User"]] = relationship("User", foreign_keys=[owner_id], primaryjoin="and_(foreign(DataSource.owner_id)==User.id, DataSource.owner_type=='user')", viewonly=True)
+    creator_user: Mapped[Optional["User"]] = relationship("User", foreign_keys=[created_by], viewonly=True)
+    owner_group: Mapped[Optional["UserGroup"]] = relationship("UserGroup", foreign_keys=[owner], viewonly=True)
 
 class Insight(Base):
     """
@@ -188,12 +190,18 @@ class Insight(Base):
     owner: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), ForeignKey("app.user_groups.id"))
     created_by: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), ForeignKey("app.users.id"))
     updated_by: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), ForeignKey("app.users.id"))
+    reviewed_by: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), ForeignKey("app.users.id"))
 
     # Legacy Polymorphic Ownership
     owner_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True))
     owner_type: Mapped[Optional[str]] = mapped_column(String(50)) # 'user' or 'group'
 
     analysis: Mapped["Analysis"] = relationship("Analysis", back_populates="insights")
+    
+    creator_user: Mapped[Optional["User"]] = relationship("User", foreign_keys=[created_by], viewonly=True)
+    owner_user: Mapped[Optional["User"]] = relationship("User", foreign_keys=[owner_id], primaryjoin="and_(foreign(Insight.owner_id)==User.id, Insight.owner_type=='user')", viewonly=True)
+    owner_group: Mapped[Optional["UserGroup"]] = relationship("UserGroup", foreign_keys=[owner], viewonly=True)
+    reviewer_user: Mapped[Optional["User"]] = relationship("User", foreign_keys=[reviewed_by], viewonly=True)
 
 
 class SystemSetting(Base):
@@ -244,6 +252,7 @@ class KnowledgePage(Base):
     owner: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), ForeignKey("app.user_groups.id"))
     created_by: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), ForeignKey("app.users.id"))
     updated_by: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), ForeignKey("app.users.id"))
+    reviewed_by: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), ForeignKey("app.users.id"))
 
     # Legacy Polymorphic Ownership
     owner_type: Mapped[str] = mapped_column(String(50), default="user") # 'user' or 'group'
@@ -252,6 +261,11 @@ class KnowledgePage(Base):
     
     # Hierarchy support
     parent_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), ForeignKey("app.knowledge_pages.id"))
+    
+    creator_user: Mapped[Optional["User"]] = relationship("User", foreign_keys=[created_by], viewonly=True)
+    owner_user: Mapped[Optional["User"]] = relationship("User", primaryjoin="and_(foreign(KnowledgePage.owner_id)==cast(User.id, String), KnowledgePage.owner_type=='user')", viewonly=True)
+    owner_group: Mapped[Optional["UserGroup"]] = relationship("UserGroup", primaryjoin="and_(foreign(KnowledgePage.owner_id)==cast(UserGroup.id, String), KnowledgePage.owner_type=='group')", viewonly=True)
+    reviewer_user: Mapped[Optional["User"]] = relationship("User", foreign_keys=[reviewed_by], viewonly=True)
     
     # source tracking
     source: Mapped[str] = mapped_column(String(50), default="manual")

--- a/src/ravioli/backend/core/schemas.py
+++ b/src/ravioli/backend/core/schemas.py
@@ -93,6 +93,12 @@ class Insight(InsightBase):
     updated_at: datetime
     created_by: Optional[UUID] = None
     updated_by: Optional[UUID] = None
+    reviewed_by: Optional[UUID] = None
+    
+    owner_user: Optional['User'] = None
+    owner_group: Optional['UserGroup'] = None
+    creator_user: Optional['User'] = None
+    reviewer_user: Optional['User'] = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -194,8 +200,9 @@ class DataSource(DataSourceBase):
     updated_by: Optional[UUID] = None
     is_duplicate: bool = False
     
-    # Optional nested owner for detail views
-    # owner: Optional[User] = None
+    owner_user: Optional['User'] = None
+    owner_group: Optional['UserGroup'] = None
+    creator_user: Optional['User'] = None
     
     model_config = ConfigDict(from_attributes=True)
 
@@ -294,5 +301,11 @@ class KnowledgePage(KnowledgePageBase):
     updated_at: datetime
     created_by: Optional[UUID] = None
     updated_by: Optional[UUID] = None
+    reviewed_by: Optional[UUID] = None
+    
+    owner_user: Optional['User'] = None
+    owner_group: Optional['UserGroup'] = None
+    creator_user: Optional['User'] = None
+    reviewer_user: Optional['User'] = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/src/ravioli/backend/main.py
+++ b/src/ravioli/backend/main.py
@@ -83,6 +83,7 @@ def _migrate_columns():
         "ALTER TABLE app.insights ADD COLUMN IF NOT EXISTS owner_type TEXT DEFAULT 'user'",
         "ALTER TABLE app.insights ADD COLUMN IF NOT EXISTS created_by UUID REFERENCES app.users(id)",
         "ALTER TABLE app.insights ADD COLUMN IF NOT EXISTS updated_by UUID REFERENCES app.users(id)",
+        "ALTER TABLE app.insights ADD COLUMN IF NOT EXISTS reviewed_by UUID REFERENCES app.users(id)",
 
         "ALTER TABLE app.knowledge_pages ADD COLUMN IF NOT EXISTS icon JSONB",
         "ALTER TABLE app.knowledge_pages ADD COLUMN IF NOT EXISTS cover JSONB",
@@ -94,6 +95,7 @@ def _migrate_columns():
         "ALTER TABLE app.knowledge_pages ADD COLUMN IF NOT EXISTS ownership_type TEXT DEFAULT 'individual'",
         "ALTER TABLE app.knowledge_pages ADD COLUMN IF NOT EXISTS created_by UUID REFERENCES app.users(id)",
         "ALTER TABLE app.knowledge_pages ADD COLUMN IF NOT EXISTS updated_by UUID REFERENCES app.users(id)",
+        "ALTER TABLE app.knowledge_pages ADD COLUMN IF NOT EXISTS reviewed_by UUID REFERENCES app.users(id)",
 
         "ALTER TABLE app.data_sources ADD COLUMN IF NOT EXISTS owner_id UUID",
         "ALTER TABLE app.data_sources ADD COLUMN IF NOT EXISTS owner_type TEXT DEFAULT 'user'",

--- a/src/ravioli/frontend/src/components/Data.ts
+++ b/src/ravioli/frontend/src/components/Data.ts
@@ -38,7 +38,7 @@ export function renderData() {
                 <th class="px-8 py-4 font-medium">Rows</th>
                 <th class="px-8 py-4 font-medium">Status</th>
                 <th class="px-8 py-4 font-medium">Timeline</th>
-                <th class="px-8 py-4 font-medium">Author</th>
+                <th class="px-8 py-4 font-medium">Owner / Creator</th>
                 <th class="px-8 py-4 font-medium text-right">Actions</th>
               </tr>
             </thead>
@@ -139,11 +139,23 @@ export function renderData() {
                     </div>
                   </td>
                   <td class="px-8 py-5">
-                    <div class="flex items-center gap-2">
-                      <div class="w-7 h-7 rounded-full bg-primary/20 flex items-center justify-center border border-primary/20">
-                        <span class="text-[10px] font-bold text-primary">${source.owner?.name?.[0] || 'A'}</span>
+                    <div class="flex flex-col gap-1.5 min-w-[140px]">
+                      <!-- Owner -->
+                      <div class="flex items-center gap-2" title="Owner">
+                        <div class="w-5 h-5 rounded-full bg-primary/20 flex items-center justify-center border border-primary/20 shrink-0">
+                          <span class="text-[8px] font-bold text-primary">${((source.owner_user?.name || source.owner_group?.name || source.owner?.name || 'Admin')[0]).toUpperCase()}</span>
+                        </div>
+                        <span class="text-xs text-neutral-300 font-medium truncate max-w-[100px]">${source.owner_user?.name || source.owner_group?.name || source.owner?.name || 'Admin'}</span>
+                        <span class="text-[8px] uppercase tracking-wider text-outline px-1 py-0.5 rounded bg-white/5 border border-white/5 shrink-0">${source.owner_group ? 'Team' : 'Owner'}</span>
                       </div>
-                      <span class="text-xs text-neutral-400 font-medium">${source.owner?.name || 'Admin'}</span>
+                      <!-- Creator -->
+                      <div class="flex items-center gap-2" title="Creator">
+                        <div class="w-5 h-5 rounded-full bg-secondary/20 flex items-center justify-center border border-secondary/20 shrink-0">
+                          <span class="text-[8px] font-bold text-secondary">${((source.creator_user?.name || 'Admin')[0]).toUpperCase()}</span>
+                        </div>
+                        <span class="text-[11px] text-neutral-500 font-medium truncate max-w-[100px]">${source.creator_user?.name || 'Admin'}</span>
+                        <span class="text-[8px] uppercase tracking-wider text-outline px-1 py-0.5 rounded bg-white/5 border border-white/5 shrink-0">Creator</span>
+                      </div>
                     </div>
                   </td>
                   <td class="px-8 py-5 text-right flex justify-end gap-2">

--- a/src/ravioli/frontend/src/components/Insights.ts
+++ b/src/ravioli/frontend/src/components/Insights.ts
@@ -27,18 +27,46 @@ function insightPill(insight: Insight) {
   const dateStr = format(new Date(insight.created_at), 'MMM d');
   const source = insight.source_label ?? 'Unknown analysis';
 
+  // Extract owner, creator, and reviewer names
+  const ownerName = insight.owner_user?.name || insight.owner_group?.name || 'Admin';
+  const ownerTypeLabel = insight.owner_group ? 'Team' : 'User';
+  const creatorName = insight.creator_user?.name || 'Admin';
+  const reviewerName = insight.reviewer_user?.name;
+
   return `
     <div class="flex items-start gap-5 py-6 border-b border-white/5 last:border-0 group insight-card-hover rounded-xl px-4 -mx-4 transition-all duration-500">
       <div class="flex flex-col items-center gap-1 shrink-0 w-12 text-center">
         <span class="text-xl font-display-lg text-primary tabular-nums group-hover:scale-110 transition-transform duration-500">${dateStr.split(' ')[1]}</span>
         <span class="text-[9px] uppercase tracking-[0.2em] text-outline opacity-40 font-bold">${dateStr.split(' ')[0]}</span>
       </div>
-      <div class="flex-1 min-w-0 space-y-2">
+      <div class="flex-1 min-w-0 space-y-3">
         <p class="text-sm font-body-md text-on-surface-variant leading-relaxed group-hover:text-white transition-colors duration-500">${insight.content}</p>
-        <div class="flex items-center gap-2">
-          <span class="material-symbols-outlined text-primary text-xs opacity-50 group-hover:opacity-100 transition-opacity" data-icon="verified">verified</span>
-          <span class="text-[10px] uppercase tracking-[0.2em] text-outline font-label-sm opacity-30 group-hover:opacity-60 transition-opacity">${source}</span>
-          <span class="text-[10px] text-outline opacity-20">·</span>
+        <div class="flex flex-wrap items-center gap-y-2 gap-x-4">
+          <div class="flex items-center gap-2">
+            <span class="material-symbols-outlined text-primary text-xs opacity-50 group-hover:opacity-100 transition-opacity" data-icon="verified">verified</span>
+            <span class="text-[10px] uppercase tracking-[0.2em] text-outline font-label-sm opacity-30 group-hover:opacity-60 transition-opacity">${source}</span>
+          </div>
+          <span class="text-[10px] text-outline opacity-20 hidden sm:inline">·</span>
+          
+          <!-- Owner & Creator metadata stack -->
+          <div class="flex items-center gap-3">
+            <div class="flex items-center gap-1.5" title="Owner (${ownerTypeLabel})">
+              <span class="material-symbols-outlined text-[12px] text-primary opacity-40">shield</span>
+              <span class="text-[9px] uppercase tracking-[0.1em] text-outline opacity-40 font-bold">${ownerName}</span>
+            </div>
+            <div class="flex items-center gap-1.5" title="Creator">
+              <span class="material-symbols-outlined text-[12px] text-secondary opacity-40">person</span>
+              <span class="text-[9px] uppercase tracking-[0.1em] text-outline opacity-40 font-bold">${creatorName}</span>
+            </div>
+            ${reviewerName ? `
+              <div class="flex items-center gap-1.5" title="Approved by Reviewer">
+                <span class="material-symbols-outlined text-[12px] text-green-400 opacity-60">fact_check</span>
+                <span class="text-[9px] uppercase tracking-[0.1em] text-green-400 font-bold">Approved by: ${reviewerName}</span>
+              </div>
+            ` : ''}
+          </div>
+          
+          <span class="text-[10px] text-outline opacity-20 hidden sm:inline">·</span>
           <span class="text-[10px] uppercase tracking-[0.2em] text-outline font-label-sm opacity-30 group-hover:opacity-60 transition-opacity">${ago}</span>
         </div>
       </div>

--- a/src/ravioli/frontend/src/components/Knowledge.ts
+++ b/src/ravioli/frontend/src/components/Knowledge.ts
@@ -152,9 +152,29 @@ export function renderKnowledge() {
               </div>
 
               <h3 class="text-2xl font-headline-md text-white mb-3 group-hover:text-primary transition-colors duration-300">${escapeHTML(page.title)}</h3>
-              <p class="text-on-surface-variant line-clamp-3 text-sm leading-relaxed mb-8 flex-1 group-hover:text-on-surface transition-colors">
+              <p class="text-on-surface-variant line-clamp-3 text-sm leading-relaxed mb-6 flex-1 group-hover:text-on-surface transition-colors">
                 ${escapeHTML(getBlocksPreview(page.content))}
               </p>
+              
+              <!-- Owner, Creator, Reviewer row -->
+              <div class="flex flex-col gap-2 mb-6 pt-4 border-t border-outline-variant/5">
+                <div class="flex flex-wrap gap-x-4 gap-y-1.5 items-center text-[10px] uppercase tracking-[0.1em] text-neutral-400">
+                  <span class="flex items-center gap-1" title="Owner (${escapeHTML(page.ownership_type)})">
+                    <span class="material-symbols-outlined text-[12px] text-primary">shield</span>
+                    <span class="font-bold">${escapeHTML(page.owner_user?.name || page.owner_group?.name || 'Admin')}</span>
+                  </span>
+                  <span class="flex items-center gap-1" title="Creator">
+                    <span class="material-symbols-outlined text-[12px] text-secondary">person</span>
+                    <span class="font-bold">${escapeHTML(page.creator_user?.name || 'Admin')}</span>
+                  </span>
+                  ${page.reviewer_user?.name ? `
+                    <span class="flex items-center gap-1 px-1.5 py-0.5 rounded bg-green-500/10 text-green-400 font-bold border border-green-500/20" title="Approved by Reviewer">
+                      <span class="material-symbols-outlined text-[10px]">fact_check</span>
+                      <span>Approved: ${escapeHTML(page.reviewer_user.name)}</span>
+                    </span>
+                  ` : ''}
+                </div>
+              </div>
               
               <div class="flex items-center justify-between mt-auto pt-6 border-t border-outline-variant/10 text-[10px] text-outline uppercase tracking-[0.2em] font-medium">
                 <span class="flex items-center gap-2">

--- a/src/ravioli/frontend/src/components/Notebook.ts
+++ b/src/ravioli/frontend/src/components/Notebook.ts
@@ -80,7 +80,7 @@ let lastLogsJson = '';
 export function renderNotebook() {
   const container = document.createElement('main');
   container.id = 'notebook-view';
-  container.className = 'flex-1 relative overflow-hidden bg-background h-screen flex flex-col';
+  container.className = 'flex-1 ml-64 relative overflow-hidden bg-background h-screen flex flex-col';
   
   updateNotebookUI(container, true);
   return container;

--- a/src/ravioli/frontend/src/types/index.ts
+++ b/src/ravioli/frontend/src/types/index.ts
@@ -74,6 +74,9 @@ export interface DataSource {
   updated_at: string;
   owner_id?: string;
   owner?: User;
+  owner_user?: User;
+  owner_group?: UserGroup;
+  creator_user?: User;
 }
 
 
@@ -105,6 +108,11 @@ export interface Insight {
   is_published: boolean;
   created_at: string;
   updated_at: string;
+  reviewed_by?: string;
+  owner_user?: User;
+  owner_group?: UserGroup;
+  creator_user?: User;
+  reviewer_user?: User;
 }
 
 export interface InsightStats {
@@ -151,6 +159,11 @@ export interface KnowledgePage {
   source_id?: string;
   created_at: string;
   updated_at: string;
+  reviewed_by?: string;
+  owner_user?: User;
+  owner_group?: UserGroup;
+  creator_user?: User;
+  reviewer_user?: User;
 }
 
 export interface KnowledgePageCreate {

--- a/tests/ravioli/backend/api/v1/endpoints/test_knowledge.py
+++ b/tests/ravioli/backend/api/v1/endpoints/test_knowledge.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, UTC
 from ravioli.backend.core.models import KnowledgePage
 
-def create_mock_page(id=None, title="Test Page", properties=None, content=None, ownership_type="individual"):
+def create_mock_page(id=None, title="Test Page", properties=None, content=None, ownership_type="individual", owner_type="individual"):
     return KnowledgePage(
         id=id or uuid.uuid4(),
         title=title,
@@ -10,7 +10,7 @@ def create_mock_page(id=None, title="Test Page", properties=None, content=None, 
         content=content or [{"type": "paragraph", "paragraph": {"rich_text": [{"text": {"content": "Hello"}}]}}],
         icon={"type": "emoji", "emoji": "📄"},
         cover={"type": "external", "external": {"url": "https://example.com/cover.jpg"}},
-        owner_type="individual",
+        owner_type=owner_type,
         ownership_type=ownership_type,
         source="manual",
         created_at=datetime.now(UTC),
@@ -53,7 +53,7 @@ def test_create_knowledge_page(client, session, current_user):
     }
     
     # Mock the return value of create to have timestamps and audit fields
-    mock_page = create_mock_page(title="New Intelligence")
+    mock_page = create_mock_page(title="New Intelligence", owner_type="team")
     def mock_add(x):
         x.id = mock_page.id
         x.created_at = mock_page.created_at
@@ -62,6 +62,7 @@ def test_create_knowledge_page(client, session, current_user):
         x.updated_by = current_user.id
         return None
     session.add.side_effect = mock_add
+    session.query.return_value.filter.return_value.first.return_value = mock_page
     
     response = client.post("/api/v1/knowledge/", json=payload)
     

--- a/tests/ravioli/backend/api/v1/endpoints/test_knowledge.py
+++ b/tests/ravioli/backend/api/v1/endpoints/test_knowledge.py
@@ -54,6 +54,8 @@ def test_create_knowledge_page(client, session, current_user):
     
     # Mock the return value of create to have timestamps and audit fields
     mock_page = create_mock_page(title="New Intelligence", owner_type="team")
+    mock_page.created_by = current_user.id
+    mock_page.updated_by = current_user.id
     def mock_add(x):
         x.id = mock_page.id
         x.created_at = mock_page.created_at

--- a/tests/ravioli/backend/api/v1/endpoints/test_knowledge_ownership.py
+++ b/tests/ravioli/backend/api/v1/endpoints/test_knowledge_ownership.py
@@ -28,6 +28,7 @@ def test_create_knowledge_page_with_ownership_type(client, session):
     # Mock the return value of create to have timestamps
     mock_page = create_mock_page(title="New Intelligence", ownership_type="team")
     session.add.side_effect = lambda x: setattr(x, 'id', mock_page.id) or setattr(x, 'created_at', mock_page.created_at) or setattr(x, 'updated_at', mock_page.updated_at)
+    session.query.return_value.filter.return_value.first.return_value = mock_page
     
     response = client.post("/api/v1/knowledge/", json=payload)
     

--- a/tests/ravioli/backend/conftest.py
+++ b/tests/ravioli/backend/conftest.py
@@ -12,6 +12,11 @@ from ravioli.backend.core.models import User
 def session_fixture(mocker):
     """Provides a mocked SQLAlchemy session."""
     mock_session = mocker.Mock()
+    
+    # Support SQLAlchemy's eager loading options chaining
+    query_mock = mock_session.query.return_value
+    query_mock.options.return_value = query_mock
+    
     return mock_session
 
 @pytest.fixture(name="current_user")

--- a/tests/ravioli/frontend/Data.test.ts
+++ b/tests/ravioli/frontend/Data.test.ts
@@ -40,7 +40,9 @@ describe('Data component', () => {
         source_type: 'file',
         has_pii: false,
         created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
+        owner_user: { id: 'u1', name: 'John Doe', email: 'john@example.com', role: 'Operator', status: 'active' },
+        creator_user: { id: 'u2', name: 'Jane Smith', email: 'jane@example.com', role: 'Operator', status: 'active' }
       }
     ]);
     
@@ -48,6 +50,8 @@ describe('Data component', () => {
     expect(el.innerHTML).toContain('My Data');
     expect(el.innerHTML).toContain('my_data');
     expect(el.innerHTML).toContain('100');
+    expect(el.innerHTML).toContain('John Doe');
+    expect(el.innerHTML).toContain('Jane Smith');
     // Should have a file icon
     expect(el.innerHTML).toContain('description');
   });

--- a/tests/ravioli/frontend/Insights.test.ts
+++ b/tests/ravioli/frontend/Insights.test.ts
@@ -44,6 +44,32 @@ describe('Insights Component', () => {
     expect(el.innerHTML).toContain('Verified Insights');
   });
 
+  it('should render the news feed with owner, creator, and reviewer details', async () => {
+    (api.getInsightsFeed as any).mockResolvedValue([
+      {
+        id: 'ins-1',
+        analysis_id: 'an-1',
+        content: 'This is an amazing insight',
+        is_verified: true,
+        is_published: true,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        source_label: 'Custom Analysis',
+        owner_user: { id: 'u1', name: 'John Owner', email: 'owner@example.com', role: 'Operator', status: 'active' },
+        creator_user: { id: 'u2', name: 'Jane Creator', email: 'creator@example.com', role: 'Operator', status: 'active' },
+        reviewer_user: { id: 'u3', name: 'Bob Reviewer', email: 'reviewer@example.com', role: 'Admin', status: 'active' }
+      }
+    ]);
+
+    const el = renderInsights();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(el.innerHTML).toContain('This is an amazing insight');
+    expect(el.innerHTML).toContain('John Owner');
+    expect(el.innerHTML).toContain('Jane Creator');
+    expect(el.innerHTML).toContain('Bob Reviewer');
+  });
+
   describe('Expandable Summary', () => {
     it('should NOT show toggle when summary has <= 4 points', async () => {
       (api.getInsightsSummary as any).mockResolvedValue({ 

--- a/tests/ravioli/frontend/Knowledge.test.ts
+++ b/tests/ravioli/frontend/Knowledge.test.ts
@@ -46,7 +46,10 @@ describe('Knowledge Component', () => {
         icon: { type: 'emoji', emoji: '🔥' },
         cover: null,
         ownership_type: 'team',
-        updated_at: '2024-01-01T12:00:00Z'
+        updated_at: '2024-01-01T12:00:00Z',
+        owner_user: { id: 'u1', name: 'Phoenix Owner', email: 'owner@example.com', role: 'Operator', status: 'active' },
+        creator_user: { id: 'u2', name: 'Phoenix Creator', email: 'creator@example.com', role: 'Operator', status: 'active' },
+        reviewer_user: { id: 'u3', name: 'Phoenix Reviewer', email: 'reviewer@example.com', role: 'Admin', status: 'active' }
       }
     ]);
     
@@ -55,6 +58,9 @@ describe('Knowledge Component', () => {
     expect(el.innerHTML).toContain('Strategic goals for 2024');
     expect(el.innerHTML).toContain('🔥');
     expect(el.innerHTML).toContain('team');
+    expect(el.innerHTML).toContain('Phoenix Owner');
+    expect(el.innerHTML).toContain('Phoenix Creator');
+    expect(el.innerHTML).toContain('Phoenix Reviewer');
   });
 
   it('should escape HTML in titles to prevent XSS and reinterpretation errors', () => {


### PR DESCRIPTION
# Description
This PR is meant to:
1. Make sure ownership (created by & reviewed by) are visble in the frontend for Insights, Knowledge, and Data Sources to ensure accountability
2. adjust tests


# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass **locally** with my changes
- [ ] I have made corresponding changes to the documentation (i.e. `README.md` files)
- [ ] I have commented my code, particularly in hard-to-understand areas