### PR TITLE
Potential fix for code scanning alert no. 20: Information exposure through an exception

### DIFF
--- a/src/ravioli/backend/api/v1/endpoints/settings.py
+++ b/src/ravioli/backend/api/v1/endpoints/settings.py
@@ -163,9 +163,9 @@ async def debug_motherduck(db: Session = Depends(get_db)):
         try:
             schemas = conn.execute("SELECT schema_name FROM duckdb_schemas() WHERE database_name = 'ravioli'").fetchall()
             tables = conn.execute("SELECT schema_name, table_name FROM duckdb_tables() WHERE database_name = 'ravioli'").fetchall()
-        except Exception as query_err:
-            logger.error(f"Error querying ravioli schemas/tables: {query_err}", exc_info=True)
-            schemas = [(f"Error: {str(query_err)}",)]
+        except Exception:
+            logger.error("Error querying ravioli schemas/tables", exc_info=True)
+            schemas = [("Query failed",)]
             tables = []
 
         return {
@@ -178,8 +178,9 @@ async def debug_motherduck(db: Session = Depends(get_db)):
             "ravioli_schemas": [s[0] for s in schemas],
             "ravioli_tables": [{"schema": t[0], "table": t[1]} for t in tables]
         }
-    except Exception as e:
-        return {"status": "error", "error": str(e)}
+    except Exception:
+        logger.error("Unexpected error during Motherduck debug", exc_info=True)
+        return {"status": "error", "message": "An internal error occurred"}
 
 @router.get("/{key}", response_model=SystemSettingSchema)
 def get_setting(key: str, db: Session = Depends(get_db), current_user: models.User = Depends(get_current_user)):


### PR DESCRIPTION
Potential fix for [https://github.com/AI-Passione/ravioli/security/code-scanning/20](https://github.com/AI-Passione/ravioli/security/code-scanning/20)

The best fix is to keep detailed error info in server logs and return only generic, non-sensitive messages in API responses.

In `src/ravioli/backend/api/v1/endpoints/settings.py`, update `debug_motherduck` so:
- Inner query failure (`except Exception as query_err`) still logs with `exc_info=True`, but does **not** place `str(query_err)` into `schemas`.
- Outer failure (`except Exception as e`) should also log full exception server-side and return a generic error response (or `HTTPException`), without exposing exception text.

No new dependency is required. Existing `logger` is already available.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
