### PR TITLE
Potential fix for code scanning alert no. 19: Information exposure through an exception

### DIFF
--- a/src/ravioli/backend/api/v1/endpoints/settings.py
+++ b/src/ravioli/backend/api/v1/endpoints/settings.py
@@ -178,8 +178,9 @@ async def debug_motherduck(db: Session = Depends(get_db)):
             "ravioli_schemas": [s[0] for s in schemas],
             "ravioli_tables": [{"schema": t[0], "table": t[1]} for t in tables]
         }
-    except Exception as e:
-        return {"status": "error", "error": str(e)}
+    except Exception:
+        logger.exception("Error while debugging Motherduck connection/state")
+        return {"status": "error", "error": "An internal error occurred"}
 
 @router.get("/{key}", response_model=SystemSettingSchema)
 def get_setting(key: str, db: Session = Depends(get_db), current_user: models.User = Depends(get_current_user)):


### PR DESCRIPTION
Potential fix for [https://github.com/AI-Passione/ravioli/security/code-scanning/19](https://github.com/AI-Passione/ravioli/security/code-scanning/19)

The fix is to stop sending exception details to clients and instead log the exception with stack trace on the server (`logger.exception(...)` or `logger.error(..., exc_info=True)`), then return a generic error payload.

Best minimal fix (no functional change beyond removing sensitive exposure):
- File: `src/ravioli/backend/api/v1/endpoints/settings.py`
- In `debug_motherduck`, change the outer `except Exception as e:` block (lines 181–182 region) to:
  - log the exception internally with traceback,
  - return a generic error message (and optionally an unchanged status field).
- No new imports or dependencies are required since `logging`/`logger` already exist.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
