### PR TITLE
fix: lowercase GHCR owner to satisfy Docker registry requirements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,6 @@ jobs:
 
     env:
       REGISTRY: ghcr.io
-      OWNER: ${{ github.repository_owner }}
       VERSION: ${{ needs.release.outputs.version }}
       TAG:     ${{ needs.release.outputs.tag }}
 
@@ -101,6 +100,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.release.outputs.tag }}
+
+      # Docker registry tags must be lowercase — AI-Passione → ai-passione
+      - name: Lowercase owner
+        id: owner
+        run: echo "name=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -121,8 +125,8 @@ jobs:
           push: true
           # Tag with both the exact version and `latest`
           tags: |
-            ${{ env.REGISTRY }}/${{ env.OWNER }}/ravioli-backend:${{ env.TAG }}
-            ${{ env.REGISTRY }}/${{ env.OWNER }}/ravioli-backend:latest
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.name }}/ravioli-backend:${{ env.TAG }}
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.name }}/ravioli-backend:latest
           labels: |
             org.opencontainers.image.title=ravioli-backend
             org.opencontainers.image.version=${{ env.VERSION }}
@@ -138,8 +142,8 @@ jobs:
           file:    ./src/ravioli/frontend/Dockerfile
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.OWNER }}/ravioli-frontend:${{ env.TAG }}
-            ${{ env.REGISTRY }}/${{ env.OWNER }}/ravioli-frontend:latest
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.name }}/ravioli-frontend:${{ env.TAG }}
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.name }}/ravioli-frontend:latest
           labels: |
             org.opencontainers.image.title=ravioli-frontend
             org.opencontainers.image.version=${{ env.VERSION }}
@@ -153,13 +157,13 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Image | Tag |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|-----|" >> $GITHUB_STEP_SUMMARY
-          echo "| \`ghcr.io/${{ env.OWNER }}/ravioli-backend\` | \`${{ env.TAG }}\` / \`latest\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| \`ghcr.io/${{ env.OWNER }}/ravioli-frontend\` | \`${{ env.TAG }}\` / \`latest\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| \`ghcr.io/${{ steps.owner.outputs.name }}/ravioli-backend\` | \`${{ env.TAG }}\` / \`latest\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| \`ghcr.io/${{ steps.owner.outputs.name }}/ravioli-frontend\` | \`${{ env.TAG }}\` / \`latest\` |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Pull commands" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ghcr.io/${{ env.OWNER }}/ravioli-backend:${{ env.TAG }}" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ghcr.io/${{ env.OWNER }}/ravioli-frontend:${{ env.TAG }}" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ghcr.io/${{ steps.owner.outputs.name }}/ravioli-backend:${{ env.TAG }}" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ghcr.io/${{ steps.owner.outputs.name }}/ravioli-frontend:${{ env.TAG }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
   # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
github.repository_owner preserves casing (AI-Passione) but Docker registry tags must be fully lowercase. Added a 'Lowercase owner' step that pipes the value through tr to produce ai-passione before use in all image tags and summary output.

# Description
This PR is meant to:
1.  fix the release CI pipeline blocking bug
2. 
3. 

# Checklist
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass **locally** with my changes
- [ ] I have made corresponding changes to the documentation (i.e. `README.md` files)
- [ ] I have commented my code, particularly in hard-to-understand areas